### PR TITLE
Saulutations Index layout update

### DIFF
--- a/ChapsDotNET/Areas/Admin/Views/Salutations/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Salutations/Index.cshtml
@@ -1,25 +1,29 @@
 ﻿@model List<ChapsDotNET.Business.Models.SalutationModel>
+
 @{
-    ViewData["Title"] = "Salutations List";
+    ViewData["Title"] = "Salutations administration";
 }
 
-<h1>Salutations</h1>
 <p>
-    <a href='@Url.Action("Create", "Salutations")'>
-        <img src='@Url.Content("~/images/add.png")' alt="Create new salutation" />
-        Create new Salutation
-    </a>
+    <a href="">Home</a>
+    &nbsp;>&nbsp;
+    <a href="">Administration</a>
+    &nbsp;>&nbsp;
+    <a href="">Lookups</a>
+</p>
+    
+<h1>Salutations</h1>
+
+<p>
+    @Html.ActionLink("Create new Salutation", "Create", "Salutations")
 </p>
 
 <table>
+    <caption class="caption">Existing salutations</caption>
     <thead>
         <tr>
-            <th></th>
             <th>
-                Id
-            </th>
-            <th>
-                Detail
+                Title
             </th>
             <th>
                 Active
@@ -30,20 +34,13 @@
     {
         <tr>
             <td>
-                <a href='@Url.Action("Edit", "Salutations", new { id = salutation.SalutationId }, null, null)'>
-                    <img src='@Url.Content("~/images/edit.png")' alt="Edit @salutation.Detail" />
+                <a href="/Admin/Salutations/Edit/@salutation.SalutationId">
+                    @Html.DisplayFor(x => salutation.Detail)
                 </a>
             </td>
-            <td>
-                @Html.DisplayFor(x => salutation.SalutationId)
-            </td>
-            <td>
-                @Html.DisplayFor(x => salutation.Detail)
-            </td>
-            <td>
+            <td align="center">
                 @Html.DisplayFor(x => salutation.Active)
             </td>
         </tr>
     }
 </table>
-

--- a/ChapsDotNET/Areas/Admin/Views/Salutations/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Salutations/Index.cshtml
@@ -4,19 +4,19 @@
     ViewData["Title"] = "Salutations administration";
 }
 
-<p>
+<div class="breadcrumbs">
     <a href="">Home</a>
     &nbsp;>&nbsp;
     <a href="">Administration</a>
     &nbsp;>&nbsp;
     <a href="">Lookups</a>
-</p>
+</div>
     
 <h1>Salutations</h1>
 
-<p>
+<div class="actionLinks">
     @Html.ActionLink("Create new Salutation", "Create", "Salutations")
-</p>
+</div>
 
 <table>
     <caption class="caption">Existing salutations</caption>

--- a/ChapsDotNET/Properties/launchSettings.json
+++ b/ChapsDotNET/Properties/launchSettings.json
@@ -11,11 +11,10 @@
     "ChapsDotNET": {
       "commandName": "Project",
       "launchBrowser": true,
+      "applicationUrl": "https://localhost:7226;http://localhost:5226",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:7226;http://localhost:5226",
-      "dotnetRunMessages": true
+      }
     },
     "IIS Express": {
       "commandName": "IISExpress",
@@ -28,8 +27,7 @@
       "commandName": "Docker",
       "launchBrowser": true,
       "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}",
-      "publishAllPorts": true,
-      "useSSL": true
+      "environmentVariables": {}
     }
   }
 }

--- a/ChapsDotNET/Views/Shared/_Layout.cshtml
+++ b/ChapsDotNET/Views/Shared/_Layout.cshtml
@@ -9,7 +9,7 @@
         <link rel="stylesheet" type="text/css" media="screen" href="~/stylesheets/menuBar.css" />
         <link rel="stylesheet" type="text/css" media="print" href="~/stylesheets/menuBarPrint.css" />
         <link rel="stylesheet" type="text/css" href="~/stylesheets/themes/base/jquery-ui-custom.min.css" />
-        <link rel="stylesheet" type="text/css" href="~/stylesheets/site.css" />
+        <link rel="stylesheet" type="text/css" href="~/stylesheets/Site.css" />
 
         @RenderSection("head", false)
 

--- a/ChapsDotNET/Views/Shared/_Layout.cshtml
+++ b/ChapsDotNET/Views/Shared/_Layout.cshtml
@@ -74,8 +74,8 @@
                     var ServerName = "";
                     if (ServerName != "PRODUCTION") {
                         $('#menuBar li, #menuBar li.leftText, #MenuContainer, .helpButton').css('background-color', '#1d73e8');
-                        $('#first').css('background-image', 'url("images/blue_nav_left_corner_bottom.gif")');
-                        $('#MenuContainer').css('background-image', 'url("images/blue_nav_right_corner_bottom.gif")');
+                        $('#first').css('background-image', 'url("../images/blue_nav_left_corner_bottom.gif")');
+                        $('#MenuContainer').css('background-image', 'url("../images/blue_nav_right_corner_bottom.gif")');
                     }
 
                     @*var TOKENHEADERVALUE = '@TokenHeaderValue()';*@

--- a/ChapsDotNET/wwwroot/stylesheets/Site.css
+++ b/ChapsDotNET/wwwroot/stylesheets/Site.css
@@ -278,6 +278,10 @@ input[type="submit"] {
 /* MISC  
 ----------------------------------------------------------*/
 
+.actionLinks, .breadcrumbs {    
+    padding: 0.8em 0;
+}
+
 .clear {
     clear: both;
 }

--- a/ChapsDotNET/wwwroot/stylesheets/Site.css
+++ b/ChapsDotNET/wwwroot/stylesheets/Site.css
@@ -72,6 +72,15 @@ table.statement td {
 
 /* Table stuff */
 
+.caption {
+    font-size: 1.2rem;
+    font-weight: 700;
+    line-height: 1.25;
+    margin-bottom: 15px;
+    text-align: left;
+    width: max-content;
+}
+
 th {
     text-align: left;
     background-color: #dddddd;


### PR DESCRIPTION
Amended page title.
Added breadcrumbs - urls to be added.
Removed '+' image from salutation create link.
Added 'Existing salutations' caption.
Existing salutations table now just displays the salutation and active state.
Each existing salutation appears with a link.  This link should go to the salutation edit page.

![Screenshot 2022-07-20 at 17 16 20](https://user-images.githubusercontent.com/6988369/180039018-a1ebfd71-947a-4588-a0c8-92422dc7841c.png)

