### PR TITLE
Updated edit and create salutation page layouts

### DIFF
--- a/ChapsDotNET/Areas/Admin/Views/Salutations/Create.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Salutations/Create.cshtml
@@ -1,24 +1,38 @@
 ﻿@model ChapsDotNET.Models.SalutationViewModel
+
 @{
-    ViewData["Title"] = "Create New Salutation";
+    ViewData["Title"] = "Add a new salutation";
 }
+
+<div class="breadcrumbs">
+    <a href="">Home</a>
+    &nbsp;>&nbsp;
+    <a href="">Administration</a>
+    &nbsp;>&nbsp;
+    <a href="">Lookups</a>
+    &nbsp;>&nbsp;
+    <a href="/Admin/Salutations">Salutations</a>
+</div>
+
 @using (Html.BeginForm())
 {
     @Html.ValidationSummary(true)
-    <fieldset>
-        <legend>@ViewBag.Title</legend>
+
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
+
         <div class="editor-label">
-            <label>Title<span alt="Mandatory field" class="required-star">*</span></label>
+            @Html.LabelFor(model => model.Detail)
         </div>
+
         <div class="editor-field">
             @Html.EditorFor(model => model.Detail)
             @Html.ValidationMessageFor(model => model.Detail)
         </div>
 
-        <p>
-            <input type="submit" value="Create" />
-        </p>
+        <input type="submit" value="Create" />
     </fieldset>
 
 }
-

--- a/ChapsDotNET/Areas/Admin/Views/Salutations/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Salutations/Edit.cshtml
@@ -1,31 +1,47 @@
 ﻿@model ChapsDotNET.Models.SalutationViewModel
+
 @{
-    ViewData["Title"] = "Update";
+    ViewData["Title"] = "Edit an existing salutation";
 }
+
+<div class="breadcrumbs">
+    <a href="">Home</a>
+    &nbsp;>&nbsp;
+    <a href="">Administration</a>
+    &nbsp;>&nbsp;
+    <a href="">Lookups</a>
+    &nbsp;>&nbsp;
+    <a href="/Admin/Salutations">Salutations</a>
+</div>
 
 @using (Html.BeginForm())
 {
-    <fieldset>
-        <legend>@ViewBag.Title</legend>
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
+
         @Html.HiddenFor(model => model.SalutationId)
 
         <div class="editor-label">
-            <label>Title<span alt="Mandatory field" class="required-star">*</span></label>
+            @Html.LabelFor(model => model.Detail)
         </div>
+
         <div class="editor-field">
             @Html.EditorFor(model => model.Detail)
             @Html.ValidationMessageFor(model => model.Detail)
         </div>
+
         <div class="editor-label">
             @Html.LabelFor(model => model.Active)
         </div>
+
         <div class="editor-field">
-            @Html.CheckBoxFor(model => model.Active, new { @class = "form-control", @value = Model.Active = true })
+            @Html.CheckBoxFor(model => model.Active, new { @value = Model.Active = true })
             @Html.ValidationMessageFor(model => model.Active)
         </div>
-        <p>
-            <input class="button" type="submit" value="Save" />
-        </p>
+
+        <input type="submit" value="Save" />
     </fieldset>
 }
 

--- a/ChapsDotNET/wwwroot/stylesheets/Site.css
+++ b/ChapsDotNET/wwwroot/stylesheets/Site.css
@@ -221,9 +221,9 @@ footer,
 ----------------------------------------------------------*/
 
 fieldset {
-    border: 1px solid #ddd;
-    padding: 0 1.4em 1.4em 1.4em;
-    margin: 0 0 1.5em 0;
+    border: 0;
+    padding: 0;
+    margin: 0;
 }
 
 fieldset .FieldsetCR {
@@ -233,9 +233,7 @@ fieldset .FieldsetCR {
 }
 
 legend {
-    font-size: 1.2em;
-    font-weight: bold;
-    display: inline;
+    margin-bottom: 15px;
 }
 
 textarea {
@@ -420,23 +418,14 @@ ul.recordMenu-tabs > li > a {
 
 .display-label,
 .editor-label {
-    width: 16em;
-    font-weight: bold;
-    text-align: right;
-    margin: 0.5em 1em 0 0;
-    position: relative;
-    float: left;
     display: block;
-    clear: both;
+    font-weight: bold;
+    margin-bottom: 5px;
+    position: relative;
 }
 
 .editor-field {
-    font-size: 1em;
-    padding: 2px;
-    margin: 0px;
-    height: 15px;
-    line-height: normal;
-    padding-bottom: 1em;
+    margin-bottom: 15px;
 }
 
 .display-field {
@@ -710,4 +699,8 @@ div#accordion h3 {
     font-size: 11.264px;
     line-height: 14.65px;
     margin-bottom: 0;
+}
+
+.text-box_date {
+    width: 18ex;
 }


### PR DESCRIPTION
Updated salutation create and edit page layouts
Create & Edit pages:
 - Amended the page title.
 - Added Breadcrumbs.
 - Removed paragraph tags encompassing the submit buttons.
 - Removed mandatory field '*' from labels.

Site.css:
 - Removed floating and right alignment to labels and input fields.
 - Removed borders around field sets.
 - placed labels above input fields.

![salutation-add-form](https://user-images.githubusercontent.com/6988369/181784258-041cab5d-8c5a-4eff-9181-a83554e9addc.png)

![salutation-edit-form](https://user-images.githubusercontent.com/6988369/181784295-2ac92706-ce0b-406f-ad5b-0d93a3ed0be0.png)

