### PR TITLE
CDTP-407 Remove table from Reports index page

### DIFF
--- a/ChapsDotNET/Areas/Admin/Views/Reports/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Reports/Index.cshtml
@@ -16,34 +16,22 @@
 
 <h1>Reports</h1>
 
-<table>
-    @*<caption class="caption">Reports</caption>*@
-    <thead>
-        <tr>
-            <th>
-                Name
-            </th>
-            <th>
-                Description
-            </th>
-        </tr>
-    </thead>
-    @if (Model != null)
-    {
+@if (Model != null)
+{
+    <dl id="reports-list">
         @foreach (var report in Model.ToList())
         {
-            <dl>
-                <dt>
-                    <a href="/Admin/Reports/Edit/@report.ReportId">@Html.DisplayFor(x => report.Name)
-                    </a>
-                </dt>
-                <dd>
-                    @{
-                        var description = report.Description;
-                        @Html.Raw(description);
-                    }
-                </dd>
-            </dl>
+            <dt>
+                <a href="/Admin/Reports/Edit/@report.ReportId">
+                    @Html.DisplayFor(x => report.Name)
+                </a>
+            </dt>
+            <dd>
+                @{
+                    var description = report.Description;
+                    @Html.Raw(description);
+                }
+            </dd>
         }
-    }
-</table>
+    </dl>
+}

--- a/ChapsDotNET/wwwroot/stylesheets/Site.css
+++ b/ChapsDotNET/wwwroot/stylesheets/Site.css
@@ -626,6 +626,16 @@ span.ok {
     border: none !important;
 }
 
+
+dl#reports-list dt {
+    margin-bottom: 0.5em;
+}
+
+dl#reports-list dd {
+    margin-bottom: 1em;
+    margin-left: 0;
+}
+
 /* css for datepicker */
 
 .ui-datepicker-trigger {


### PR DESCRIPTION
**Context**
The Reports index page displays a list of links to reports available to the application.  This list is displayed as a Definition List (DL) in which are Data Term (DT) and Data Definition element tuples.  These contain the report names and descriptions respectively.  There seems to be a table appearing below this list which is not needed.

![reports-administration-old](https://user-images.githubusercontent.com/6988369/204821041-9385e871-d6f6-4944-a978-90bdead304a6.png)

---

**Mitigation**
The table needs to be removed and the definition list padding/margins adjusted.

![reports-administration-new](https://user-images.githubusercontent.com/6988369/204821133-62053164-c01b-40be-b64f-eb02c80ef98a.png)

**Ticket:**
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/864?modal=detail&selectedIssue=CDPT-407
