### PR TITLE
CDPT-392 Filter MP admin index page list.

### DIFF
--- a/ChapsDotNET.Business.Tests/ChapsDotNET.Business.Tests.csproj
+++ b/ChapsDotNET.Business.Tests/ChapsDotNET.Business.Tests.csproj
@@ -22,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ChapsDotNET.Business.Tests/MPComponentTests.cs
+++ b/ChapsDotNET.Business.Tests/MPComponentTests.cs
@@ -249,7 +249,7 @@ namespace ChapsDotNET.Business.Tests
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                activeFilter = false
+                ActiveFilter = false
             });
 
             // Assert
@@ -273,7 +273,7 @@ namespace ChapsDotNET.Business.Tests
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                activeFilter = false
+                ActiveFilter = false
             });
 
             // Assert
@@ -742,8 +742,8 @@ namespace ChapsDotNET.Business.Tests
             // Act
             var result = await mpComponent.GetMPsAsync( new MPRequestModel
             {
-               nameFilterTerm = "RTHON",
-               activeFilter = false
+               NameFilterTerm = "RTHON",
+               ActiveFilter = false
             });
 
             // Assert
@@ -841,8 +841,8 @@ namespace ChapsDotNET.Business.Tests
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                nameFilterTerm = "THON",
-                activeFilter = false
+                NameFilterTerm = "THON",
+                ActiveFilter = false
             });
 
             // Assert
@@ -940,8 +940,8 @@ namespace ChapsDotNET.Business.Tests
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                nameFilterTerm = "N",
-                activeFilter = false
+                NameFilterTerm = "N",
+                ActiveFilter = false
             });
 
             // Assert
@@ -1039,8 +1039,8 @@ namespace ChapsDotNET.Business.Tests
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                nameFilterTerm = "ON",
-                activeFilter = false
+                NameFilterTerm = "ON",
+                ActiveFilter = false
             });
 
             // Assert
@@ -1138,8 +1138,8 @@ namespace ChapsDotNET.Business.Tests
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                nameFilterTerm = "N",
-                activeFilter = false
+                NameFilterTerm = "N",
+                ActiveFilter = false
             });
 
             // Assert
@@ -1199,8 +1199,8 @@ namespace ChapsDotNET.Business.Tests
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                addressFilterTerm = "THE LANE",
-                activeFilter = false
+                AddressFilterTerm = "THE LANE",
+                ActiveFilter = false
             });
 
             // Assert
@@ -1260,8 +1260,8 @@ namespace ChapsDotNET.Business.Tests
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                emailFilterTerm = "Earth",
-                activeFilter = false
+                EmailFilterTerm = "Earth",
+                ActiveFilter = false
             });
 
             // Assert
@@ -1321,7 +1321,7 @@ namespace ChapsDotNET.Business.Tests
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                activeFilter = true
+                ActiveFilter = true
             });
 
             // Assert

--- a/ChapsDotNET.Business.Tests/MPComponentTests.cs
+++ b/ChapsDotNET.Business.Tests/MPComponentTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bogus;
 using ChapsDotNET.Business.Components;
 using ChapsDotNET.Business.Exceptions;
+using ChapsDotNET.Business.Interfaces;
 using ChapsDotNET.Business.Models.Common;
 using ChapsDotNET.Business.Tests.Common;
 using ChapsDotNET.Data.Entities;
@@ -13,6 +14,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
+using NSubstitute;
 
 namespace ChapsDotNET.Business.Tests
 {
@@ -43,7 +45,9 @@ namespace ChapsDotNET.Business.Tests
             );
             await context.SaveChangesAsync();
 
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
+
 
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel());
@@ -147,7 +151,8 @@ namespace ChapsDotNET.Business.Tests
 
             await context.SaveChangesAsync();
 
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
 
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel());
@@ -158,8 +163,8 @@ namespace ChapsDotNET.Business.Tests
             result.Results?.All(x => x.Active).Should().BeTrue();
         }
 
-        [Fact(DisplayName = "Get a list of all MPs when GetMPsAsync method is called with ShowActiveInactive in the parameter")]
-        public async Task GetAListOfActiveAndInactiveMPsWhenGetMPsAsyncIsCalled()
+        [Fact(DisplayName = "Get a list of all MPs when GetMPsAsync method is called with Show Active in the parameter")]
+        public async Task GetAListOfActiveMPsWhenGetMPsAsyncIsCalled()
         {
             // Arrange
             var context = DataContextFactory.Create();
@@ -238,12 +243,13 @@ namespace ChapsDotNET.Business.Tests
 
             await context.SaveChangesAsync();
 
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
 
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                ShowActiveAndInactive = true
+                activeFilter = false
             });
 
             // Assert
@@ -261,12 +267,13 @@ namespace ChapsDotNET.Business.Tests
                 .ToList();
             await context.MPs.AddRangeAsync(fakeMPs);
             await context.SaveChangesAsync();
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
 
             // Act
             var result = await mpComponent.GetMPsAsync(new MPRequestModel
             {
-                ShowActiveAndInactive = true
+                activeFilter = false
             });
 
             // Assert
@@ -324,7 +331,8 @@ namespace ChapsDotNET.Business.Tests
 
             await context.SaveChangesAsync();
 
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
 
             // Act
             var result = await mpComponent.GetMPAsync(44);
@@ -393,7 +401,8 @@ namespace ChapsDotNET.Business.Tests
 
             await context.SaveChangesAsync();
 
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
 
             // Act
             var result = await mpComponent.GetMPAsync(53);
@@ -418,7 +427,8 @@ namespace ChapsDotNET.Business.Tests
         {
             // Arrange
             var context = DataContextFactory.Create();
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
             var newrecord = new Models.MPModel
             {
                 MPId = 8,
@@ -462,7 +472,8 @@ namespace ChapsDotNET.Business.Tests
         {
             // Arrange
             var context = DataContextFactory.Create();
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
             var newrecord = new Models.MPModel
             {
                 MPId = 8,
@@ -514,7 +525,8 @@ namespace ChapsDotNET.Business.Tests
 
             await context.SaveChangesAsync();
 
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
 
             // Act
             await mpComponent.UpdateMPAsync(new Models.MPModel
@@ -576,7 +588,8 @@ namespace ChapsDotNET.Business.Tests
             });
 
             await context.SaveChangesAsync();
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
 
             // Act
             Func<Task> act = async () => { await mpComponent.UpdateMPAsync(new Models.MPModel()); };
@@ -610,7 +623,8 @@ namespace ChapsDotNET.Business.Tests
             });
 
             await context.SaveChangesAsync();
-            var mpComponent = new MPComponent(context);
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
 
             // Act
             Func<Task> act = async () =>

--- a/ChapsDotNET.Business.Tests/MPComponentTests.cs
+++ b/ChapsDotNET.Business.Tests/MPComponentTests.cs
@@ -20,8 +20,8 @@ namespace ChapsDotNET.Business.Tests
 {
     public class MPComponentTests
     {
-        [Fact(DisplayName = "Get a list of MPs when GetMPsAsync method is called")]
-        public async Task GetAListOfMPsWhenGetMPsAsyncMethodIsCalled()
+        [Fact(DisplayName = "Get a list of all MPs when GetMPsAsync method is called")]
+        public async Task GetAListOfAllMPsWhenGetMPsAsyncMethodIsCalled()
         {
             // Arrange
             var context = DataContextFactory.Create();
@@ -650,6 +650,683 @@ namespace ChapsDotNET.Business.Tests
 
             //Assert
             await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact(DisplayName = "Typing 'RTHON' in the Name filter should return a list of all Right Honourable MPs")]
+        public async Task TypingRTHONTheNameFilterShouldReturnAListOfAllRightHonourableMPs()
+        {
+            // Arrange
+            var context = DataContextFactory.Create();
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 1,
+                    RtHon = true,
+                    SalutationID = 3,
+                    Surname = "Dax",
+                    FirstNames = "Jadzia",
+                    Email = "jadzia.daxy@starfleet.com",
+                    AddressLine1 = "Deep Space Nine",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "",
+                    County = "",
+                    Postcode = "XX33 Q45",
+                    Suffix = "PHD",
+                    active = true
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 2,
+                    RtHon = true,
+                    SalutationID = 28,
+                    Surname = "Jurati",
+                    FirstNames = "Agnes",
+                    Email = "agnes.jurati@daystrom-institute.com",
+                    AddressLine1 = "Daystrom Institute",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "Okinawa",
+                    County = "",
+                    Postcode = "JP01 8AN",
+                    Suffix = "",
+                    active = false
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 3,
+                    RtHon = false,
+                    SalutationID = 3,
+                    Surname = "Soong",
+                    FirstNames = "Noonian",
+                    Email = "n.soong@.com",
+                    AddressLine1 = "colony 44",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "",
+                    County = "",
+                    Postcode = "",
+                    Suffix = "",
+                    active = true
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 4,
+                    RtHon = false,
+                    SalutationID = 28,
+                    Surname = "Asha",
+                    FirstNames = "Soji",
+                    Email = "sofi.asha@earth.com",
+                    AddressLine1 = "123 The Lane",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "New York",
+                    County = "",
+                    Postcode = "NY00 2BD",
+                    Suffix = "",
+                    active = false
+                }
+            );
+
+            await context.SaveChangesAsync();
+
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
+
+            // Act
+            var result = await mpComponent.GetMPsAsync( new MPRequestModel
+            {
+               nameFilterTerm = "RTHON",
+               activeFilter = false
+            });
+
+            // Assert
+            result.Results.Should().NotBeNull();
+            result.Results.Should().HaveCount(2);
+        }
+
+        [Fact(DisplayName = "Typing 'THON' in the Name filter should return a list of all MPs with 'THON' in their name")]
+        public async Task TypingTHONinTheNameFilterShouldReturnAListOfAllRightHonourableMPs()
+        {
+            // Arrange
+            var context = DataContextFactory.Create();
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 1,
+                    RtHon = true,
+                    SalutationID = 3,
+                    Surname = "Dax",
+                    FirstNames = "Jadzia",
+                    Email = "jadzia.daxy@starfleet.com",
+                    AddressLine1 = "Deep Space Nine",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "",
+                    County = "",
+                    Postcode = "XX33 Q45",
+                    Suffix = "PHD",
+                    active = true
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 2,
+                    RtHon = true,
+                    SalutationID = 28,
+                    Surname = "Jurati",
+                    FirstNames = "Agnes",
+                    Email = "agnes.jurati@daystrom-institute.com",
+                    AddressLine1 = "Daystrom Institute",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "Okinawa",
+                    County = "",
+                    Postcode = "JP01 8AN",
+                    Suffix = "",
+                    active = false
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 3,
+                    RtHon = false,
+                    SalutationID = 3,
+                    Surname = "Archer",
+                    FirstNames = "Jonathon",
+                    Email = "j.archer@starfleet.com",
+                    AddressLine1 = "colony 44",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "",
+                    County = "",
+                    Postcode = "",
+                    Suffix = "",
+                    active = true
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 4,
+                    RtHon = false,
+                    SalutationID = 28,
+                    Surname = "Asha",
+                    FirstNames = "Soji",
+                    Email = "sofi.asha@earth.com",
+                    AddressLine1 = "123 The Lane",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "New York",
+                    County = "",
+                    Postcode = "NY00 2BD",
+                    Suffix = "",
+                    active = false
+                }
+            );
+
+            await context.SaveChangesAsync();
+
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
+
+            // Act
+            var result = await mpComponent.GetMPsAsync(new MPRequestModel
+            {
+                nameFilterTerm = "THON",
+                activeFilter = false
+            });
+
+            // Assert
+            result.Results.Should().NotBeNull();
+            result.Results.Should().HaveCount(3);
+        }
+
+        [Fact(DisplayName = "Typing 'HON' in the Name filter should return a list of all MPs with 'HON' in their name")]
+        public async Task TypingHONinTheNameFilterShouldReturnAListOfAllMPsWithHONInTheirName()
+        {
+            // Arrange
+            var context = DataContextFactory.Create();
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 1,
+                    RtHon = true,
+                    SalutationID = 3,
+                    Surname = "Dax",
+                    FirstNames = "Jadzia",
+                    Email = "jadzia.daxy@starfleet.com",
+                    AddressLine1 = "Deep Space Nine",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "",
+                    County = "",
+                    Postcode = "XX33 Q45",
+                    Suffix = "PHD",
+                    active = true
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 2,
+                    RtHon = true,
+                    SalutationID = 28,
+                    Surname = "Jurati",
+                    FirstNames = "Agnes",
+                    Email = "agnes.jurati@daystrom-institute.com",
+                    AddressLine1 = "Daystrom Institute",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "Okinawa",
+                    County = "",
+                    Postcode = "JP01 8AN",
+                    Suffix = "",
+                    active = false
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 3,
+                    RtHon = false,
+                    SalutationID = 3,
+                    Surname = "Frakes",
+                    FirstNames = "Jonathon",
+                    Email = "j.frakes@paramount.com",
+                    AddressLine1 = "colony 44",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "",
+                    County = "",
+                    Postcode = "",
+                    Suffix = "",
+                    active = true
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 4,
+                    RtHon = false,
+                    SalutationID = 28,
+                    Surname = "Rapp",
+                    FirstNames = "Anthony",
+                    Email = "a.rapp@earth.com",
+                    AddressLine1 = "123 The Lane",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "New York",
+                    County = "",
+                    Postcode = "NY00 2BD",
+                    Suffix = "",
+                    active = false
+                }
+            );
+
+            await context.SaveChangesAsync();
+
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
+
+            // Act
+            var result = await mpComponent.GetMPsAsync(new MPRequestModel
+            {
+                nameFilterTerm = "N",
+                activeFilter = false
+            });
+
+            // Assert
+            result.Results.Should().NotBeNull();
+            result.Results.Should().HaveCount(4);
+        }
+
+        [Fact(DisplayName = "Typing 'ON' in the Name filter should return a list of all MPs with 'ON' in their name")]
+        public async Task TypingONinTheNameFilterShouldReturnAListOfAllMPsWithONInTheirName()
+        {
+            // Arrange
+            var context = DataContextFactory.Create();
+
+            await context.MPs.AddAsync(new MP
+            {
+                MPID = 1,
+                RtHon = true,
+                SalutationID = 3,
+                Surname = "McCoy",
+                FirstNames = "Leonard",
+                Email = "l.mcoy@starfleet.com",
+                AddressLine1 = "Star base 10",
+                AddressLine2 = "",
+                AddressLine3 = "",
+                Town = "",
+                County = "",
+                Postcode = "XX33 Q45",
+                Suffix = "PHD",
+                active = true
+            }
+            );
+
+            await context.MPs.AddAsync(new MP
+            {
+                MPID = 2,
+                RtHon = true,
+                SalutationID = 28,
+                Surname = "Scott",
+                FirstNames = "Montgomery",
+                Email = "m.scott@starfleet.com",
+                AddressLine1 = "Starfleet HQ",
+                AddressLine2 = "",
+                AddressLine3 = "",
+                Town = "San Francisco",
+                County = "",
+                Postcode = "JP01 8AN",
+                Suffix = "",
+                active = false
+            }
+            );
+
+            await context.MPs.AddAsync(new MP
+            {
+                MPID = 3,
+                RtHon = false,
+                SalutationID = 3,
+                Surname = "Soong",
+                FirstNames = "Noonian",
+                Email = "n.soong@.com",
+                AddressLine1 = "colony 44",
+                AddressLine2 = "",
+                AddressLine3 = "",
+                Town = "",
+                County = "",
+                Postcode = "",
+                Suffix = "",
+                active = true
+            }
+            );
+
+            await context.MPs.AddAsync(new MP
+            {
+                MPID = 4,
+                RtHon = false,
+                SalutationID = 28,
+                Surname = "Asha",
+                FirstNames = "Soji",
+                Email = "sofi.asha@earth.com",
+                AddressLine1 = "123 The Lane",
+                AddressLine2 = "",
+                AddressLine3 = "",
+                Town = "New York",
+                County = "",
+                Postcode = "NY00 2BD",
+                Suffix = "",
+                active = false
+            }
+            );
+
+            await context.SaveChangesAsync();
+
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
+
+            // Act
+            var result = await mpComponent.GetMPsAsync(new MPRequestModel
+            {
+                nameFilterTerm = "ON",
+                activeFilter = false
+            });
+
+            // Assert
+            result.Results.Should().NotBeNull();
+            result.Results.Should().HaveCount(3);
+        }
+
+        [Fact(DisplayName = "Typing 'N' in the Name filter should return a list of all MPs with 'N' in their name")]
+        public async Task TypingNinTheNameFilterShouldReturnAListOfAllMPsWithNInTheirName()
+        {
+            // Arrange
+            var context = DataContextFactory.Create();
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 1,
+                    RtHon = true,
+                    SalutationID = 3,
+                    Surname = "Dax",
+                    FirstNames = "Jadzia",
+                    Email = "jadzia.dax@starfleet.com",
+                    AddressLine1 = "Deep Space Nine",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "",
+                    County = "",
+                    Postcode = "XX33 Q45",
+                    Suffix = "PHD",
+                    active = true
+                }
+            );
+                
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 2,
+                    RtHon = true,
+                    SalutationID = 28,
+                    Surname = "Jurati",
+                    FirstNames = "Agnes",
+                    Email = "agnes.jurati@daystrom-institute.com",
+                    AddressLine1 = "Daystrom Institute",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "Okinawa",
+                    County = "",
+                    Postcode = "JP01 8AN",
+                    Suffix = "",
+                    active = false
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 3,
+                    RtHon = false,
+                    SalutationID = 3,
+                    Surname = "Soong",
+                    FirstNames = "Noonian",
+                    Email = "n.soong@.com",
+                    AddressLine1 = "colony 44",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "",
+                    County = "",
+                    Postcode = "",
+                    Suffix = "",
+                    active = true
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 4,
+                    RtHon = false,
+                    SalutationID = 28,
+                    Surname = "Asha",
+                    FirstNames = "Dahj",
+                    Email = "dahj.asha@earth.com",
+                    AddressLine1 = "123 The Lane",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "New York",
+                    County = "",
+                    Postcode = "NY00 2BD",
+                    Suffix = "",
+                    active = false
+                }
+            );
+
+            await context.SaveChangesAsync();
+
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
+
+            // Act
+            var result = await mpComponent.GetMPsAsync(new MPRequestModel
+            {
+                nameFilterTerm = "N",
+                activeFilter = false
+            });
+
+            // Assert
+            result.Results.Should().NotBeNull();
+            result.Results.Should().HaveCount(3);
+        }
+
+        [Fact(DisplayName = "Typing 'THE LANE' in the Name filter should return a list of all MPs with 'The Lane' in their address")]
+        public async Task TypingTHELANEInTheNameFilterShouldReturnAListOfAllMPsWithTheLaneInTheirAddress()
+        {
+            // Arrange
+            var context = DataContextFactory.Create();
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 1,
+                    RtHon = false,
+                    SalutationID = 3,
+                    Surname = "Soong",
+                    FirstNames = "Noonian",
+                    Email = "n.soong@colony44.com",
+                    AddressLine1 = "Colony 44",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "",
+                    County = "",
+                    Postcode = "",
+                    Suffix = "",
+                    active = true
+                }
+            );
+
+            await context.MPs.AddAsync(new MP
+                {
+                    MPID = 2,
+                    RtHon = false,
+                    SalutationID = 28,
+                    Surname = "Asha",
+                    FirstNames = "Soji",
+                    Email = "sofi.asha@earth.com",
+                    AddressLine1 = "123 The Lane",
+                    AddressLine2 = "",
+                    AddressLine3 = "",
+                    Town = "New York",
+                    County = "",
+                    Postcode = "NY00 2BD",
+                    Suffix = "",
+                    active = false
+                }
+            );
+
+            await context.SaveChangesAsync();
+
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
+
+            // Act
+            var result = await mpComponent.GetMPsAsync(new MPRequestModel
+            {
+                addressFilterTerm = "THE LANE",
+                activeFilter = false
+            });
+
+            // Assert
+            result.Results.Should().NotBeNull();
+            result.Results.Should().HaveCount(1);
+        }
+
+        [Fact(DisplayName = "Typing 'Earth' in the Email filter should return a list of all MPs with 'Earth' in their email address")]
+        public async Task TypingEarthInTheEmailFilterShouldReturnAListOfAllMPsWithEarthInTheirEmailAddress()
+        {
+            // Arrange
+            var context = DataContextFactory.Create();
+
+            await context.MPs.AddAsync(new MP
+            {
+                MPID = 1,
+                RtHon = false,
+                SalutationID = 3,
+                Surname = "Soong",
+                FirstNames = "Noonian",
+                Email = "n.soong@colony44.com",
+                AddressLine1 = "colony 44",
+                AddressLine2 = "",
+                AddressLine3 = "",
+                Town = "",
+                County = "",
+                Postcode = "",
+                Suffix = "",
+                active = true
+            }
+            );
+
+            await context.MPs.AddAsync(new MP
+            {
+                MPID = 2,
+                RtHon = false,
+                SalutationID = 28,
+                Surname = "Asha",
+                FirstNames = "Soji",
+                Email = "sofi.asha@earth.com",
+                AddressLine1 = "123 The Lane",
+                AddressLine2 = "",
+                AddressLine3 = "",
+                Town = "New York",
+                County = "",
+                Postcode = "NY00 2BD",
+                Suffix = "",
+                active = false
+            }
+            );
+
+            await context.SaveChangesAsync();
+
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
+
+            // Act
+            var result = await mpComponent.GetMPsAsync(new MPRequestModel
+            {
+                emailFilterTerm = "Earth",
+                activeFilter = false
+            });
+
+            // Assert
+            result.Results.Should().NotBeNull();
+            result.Results.Should().HaveCount(1);
+        }
+
+        [Fact(DisplayName = "Clicking on the 'Only Active' filter should return a list of only 'Active' MP records")]
+        public async Task ClickingOnTheOnlyActiveFilterShouldReturnAListOfOnlyActiveMPRecords()
+        {
+            // Arrange
+            var context = DataContextFactory.Create();
+
+            await context.MPs.AddAsync(new MP
+            {
+                MPID = 1,
+                RtHon = true,
+                SalutationID = 3,
+                Surname = "McCoy",
+                FirstNames = "Leonard",
+                Email = "l.mcoy@starfleet.com",
+                AddressLine1 = "Star base 10",
+                AddressLine2 = "",
+                AddressLine3 = "",
+                Town = "",
+                County = "",
+                Postcode = "XX33 Q45",
+                Suffix = "PHD",
+                active = true
+            }
+            );
+
+            await context.MPs.AddAsync(new MP
+            {
+                MPID = 2,
+                RtHon = true,
+                SalutationID = 28,
+                Surname = "Scott",
+                FirstNames = "Montgomery",
+                Email = "m.scott@starfleet.com",
+                AddressLine1 = "Starfleet HQ",
+                AddressLine2 = "",
+                AddressLine3 = "",
+                Town = "San Francisco",
+                County = "",
+                Postcode = "JP01 8AN",
+                Suffix = "",
+                active = false
+            }
+            );
+
+            await context.SaveChangesAsync();
+
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            var mpComponent = new MPComponent(context, mockSalutationComponent);
+
+            // Act
+            var result = await mpComponent.GetMPsAsync(new MPRequestModel
+            {
+                activeFilter = true
+            });
+
+            // Assert
+            result.Results.Should().NotBeNull();
+            result.Results.Should().HaveCount(1);
         }
     }
 }

--- a/ChapsDotNET.Business.Tests/PublicHolidayComponentTests.cs
+++ b/ChapsDotNET.Business.Tests/PublicHolidayComponentTests.cs
@@ -197,7 +197,7 @@ namespace ChapsDotNET.Business.Tests
             {
                 PublicHolidayId = 1,
                 Description = "New Year's Day",
-                Date = new DateTime(2023, 01, 01)
+                Date = new DateTime(2056, 01, 01)
             };
 
             var publicHolidayComponent = new PublicHolidayComponent(context);
@@ -254,7 +254,7 @@ namespace ChapsDotNET.Business.Tests
             {
                 PublicHolidayID = 1,
                 Description = "New Year's Day",
-                Date = new DateTime(2022, 01, 01)
+                Date = new DateTime(2056, 01, 01)
             });
 
             await context.SaveChangesAsync();
@@ -266,7 +266,7 @@ namespace ChapsDotNET.Business.Tests
                 {
                     PublicHolidayId = 1,
                     Description = "New Year's Day",
-                    Date = new DateTime(2023, 01, 01)
+                    Date = new DateTime(2056, 01, 01)
                 });
             };
 
@@ -284,7 +284,7 @@ namespace ChapsDotNET.Business.Tests
             {
                 PublicHolidayID = 1,
                 Description = "New Year's Day",
-                Date = new DateTime(2023, 01, 01)
+                Date = new DateTime(2056, 01, 01)
             });
 
             var publicHolidayComponent = new PublicHolidayComponent(context);
@@ -296,7 +296,7 @@ namespace ChapsDotNET.Business.Tests
                 {
                     PublicHolidayId = 1,
                     Description = "",
-                    Date = new DateTime(2023, 01, 01)
+                    Date = new DateTime(2056, 01, 01)
                 });
             };
 

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -39,12 +39,37 @@ namespace ChapsDotNET.Business.Components
         {
             var query = _context.MPs.AsQueryable();
 
-            if (!request.ShowActiveAndInactive)
-            {
-                query = query.Where(x => x.active == true);
-            }
+            // Filtering ------------------------------------------------------
 
-            query = query.OrderBy(x => x.Surname);
+			if (!string.IsNullOrWhiteSpace(request.nameFilterTerm))
+            {
+                //TODO: RtHon -> boolean
+                //TODO: Salutation -> foreign key
+                query = query.Where(
+                    x => x.FirstNames!.ToLower().Contains(request.nameFilterTerm.ToLower()) ||
+                    x.Surname.ToLower().Contains(request.nameFilterTerm.ToLower()) ||
+                    x.Suffix!.ToLower().Contains(request.nameFilterTerm.ToLower())
+                );
+			}
+            else if (!string.IsNullOrWhiteSpace(request.addressFilterTerm))
+            {
+                query = query.Where(
+                    x => x.AddressLine1!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
+                    x.AddressLine2!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
+                    x.AddressLine3!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
+                    x.Town!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
+                    x.County!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
+                    x.Postcode!.ToLower().Contains(request.addressFilterTerm.ToLower())
+                );
+			}
+            else if (!string.IsNullOrWhiteSpace(request.emailFilterTerm))
+            {
+                query = query.Where(
+                    x => x.Email!.ToLower().Contains(request.emailFilterTerm.ToLower())
+                );
+			}
+
+            // ----------------------------------------------------------------
 
             //Row Count
             var count = await query.CountAsync();

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -15,10 +15,12 @@ namespace ChapsDotNET.Business.Components
     public class MPComponent : IMPComponent
     {
         private readonly DataContext _context;
+        private readonly ISalutationComponent _salutationComponent;
 
-        public MPComponent(DataContext context)
+        public MPComponent(DataContext context, ISalutationComponent salutationComponent)
         {
             _context = context;
+            _salutationComponent = salutationComponent;
         }
 
         /// <summary>
@@ -82,12 +84,6 @@ namespace ChapsDotNET.Business.Components
             {
                 query = query
                     .Where(x => x.active.Equals(true));
-            }
-
-            if (request.activeFilter == false)
-            {
-                query = query
-                    .Where(x => x.active.Equals(false));
             }
 
             query = query
@@ -224,6 +220,34 @@ namespace ChapsDotNET.Business.Components
 
             _context.MPs.Update(mp);
             await _context.SaveChangesAsync();
+        }
+
+        public async Task<string> DisplayFullName(int id)
+        {
+            var mpmodel = await GetMPAsync(id);
+            string? salutation = null;
+            if (mpmodel.SalutationId != null)
+            {
+                salutation = _salutationComponent.GetSalutationAsync((int)mpmodel.SalutationId).Result.Detail;
+            }
+            else
+            {
+                salutation = String.Empty;
+            }
+           
+            List<string> nameParts = new List<string>();
+
+            if (mpmodel.RtHon == true)
+            {
+                nameParts.Add("Rt Hon");
+            }
+
+            nameParts.Add(salutation!);
+            nameParts.Add(mpmodel.FirstNames != null ? mpmodel.FirstNames : null!);
+            nameParts.Add(mpmodel.Surname);
+            nameParts.Add(mpmodel.Suffix != null ? mpmodel.Suffix : null!);
+            var tep = string.Join(" ", nameParts.Where(s => !string.IsNullOrEmpty(s)));
+            return string.Join(" ", nameParts.Where(s => !string.IsNullOrEmpty(s)));
         }
     }
 }

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -28,56 +28,46 @@ namespace ChapsDotNET.Business.Components
         {
             var query = _context.MPs.Include(x => x.Salutation).AsQueryable();
 
-            // Filtering ------------------------------------------------------
+            // Filtering
 
-            if (
-                string.IsNullOrWhiteSpace(request.nameFilterTerm) &&
-                string.IsNullOrWhiteSpace(request.addressFilterTerm) &&
-                string.IsNullOrWhiteSpace(request.emailFilterTerm) &&
-                request.activeFilter.Equals(null)
-                )
+            if (!string.IsNullOrWhiteSpace(request.nameFilterTerm))
             {
-                query = query.Where(x => x.active.Equals(true));
-            }
-            else
-            {
-                if (!string.IsNullOrWhiteSpace(request.nameFilterTerm))
-                {
-                    query = query
-                        .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!)
-                        .Contains(request.nameFilterTerm.Replace(" ", "").ToLower())
-                    );
-                }
-
-                if (!string.IsNullOrWhiteSpace(request.addressFilterTerm))
-                {
-                    query = query
-                        .Where(x => (x.AddressLine1! + x.AddressLine2! + x.AddressLine3! + x.Town! + x.County! + x.Postcode!)
-                        .Contains(request.addressFilterTerm.Replace(" ", "").ToLower())
-                    );
-                }
-
-                if (!string.IsNullOrWhiteSpace(request.emailFilterTerm))
-                {
-                    query = query
-                        .Where(x => x.Email!.ToLower()
-                        .Contains(request.emailFilterTerm.ToLower()));
-                }
-
-                if (request.activeFilter == true)
-                {
-                    query = query.Where(x => x.active.Equals(true));
-                }
-
-                if (request.activeFilter == false)
-                {
-                    query = query.Where(x => x.active.Equals(false));
-                }
+                query = query
+                    .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!)
+                    .Contains(request.nameFilterTerm.Replace(" ", "").ToLower())
+                );
             }
 
-            query = query.OrderBy(x => x.Surname).ThenBy(x => x.FirstNames);
+            if (!string.IsNullOrWhiteSpace(request.addressFilterTerm))
+            {
+                query = query
+                    .Where(x => (x.AddressLine1! + x.AddressLine2! + x.AddressLine3! + x.Town! + x.County! + x.Postcode!)
+                    .Contains(request.addressFilterTerm.Replace(" ", "").ToLower())
+                );
+            }
 
-            // ----------------------------------------------------------------
+            if (!string.IsNullOrWhiteSpace(request.emailFilterTerm))
+            {
+                query = query
+                    .Where(x => x.Email!.ToLower()
+                    .Contains(request.emailFilterTerm.ToLower()));
+            }
+
+            if (request.activeFilter == true)
+            {
+                query = query
+                    .Where(x => x.active.Equals(true));
+            }
+
+            if (request.activeFilter == false)
+            {
+                query = query
+                    .Where(x => x.active.Equals(false));
+            }
+
+            query = query
+                .OrderBy(x => x.Surname)
+                .ThenBy(x => x.FirstNames);
 
             //Row Count
             var count = await query.CountAsync();

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -51,7 +51,7 @@ namespace ChapsDotNET.Business.Components
                     x.Suffix!.ToLower().Contains(request.nameFilterTerm.ToLower())
                 );
 			}
-            else if (!string.IsNullOrWhiteSpace(request.addressFilterTerm))
+            if (!string.IsNullOrWhiteSpace(request.addressFilterTerm))
             {
                 query = query.Where(
                     x => x.AddressLine1!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
@@ -62,7 +62,7 @@ namespace ChapsDotNET.Business.Components
                     x.Postcode!.ToLower().Contains(request.addressFilterTerm.ToLower())
                 );
 			}
-            else if (!string.IsNullOrWhiteSpace(request.emailFilterTerm))
+            if (!string.IsNullOrWhiteSpace(request.emailFilterTerm))
             {
                 query = query.Where(
                     x => x.Email!.ToLower().Contains(request.emailFilterTerm.ToLower())

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using ChapsDotNET.Business.Exceptions;
 using ChapsDotNET.Business.Interfaces;
 using ChapsDotNET.Business.Models;
@@ -31,21 +33,33 @@ namespace ChapsDotNET.Business.Components
 
             // Filtering
 
-            if (!string.IsNullOrWhiteSpace(request.nameFilterTerm))
-            {
-                string nameTerm =  request.nameFilterTerm.Replace(" ", "").ToLower();
-                string rtHon = "rthon";
+            if (!string.IsNullOrWhiteSpace(request.nameFilterTerm)) {
+                bool includeRtHonourables = false;
+                string characterPattern = @"/(rtho)|(thon)|(rth)|(tho)|(hon)|(rt)|(th)|(ho)|(on)|[rthon]/";
+                string name =  request.nameFilterTerm.Replace(" ", "").ToLower();
+                Regex regularExpression = new Regex(characterPattern);
+                
+                switch (name.Length) {
+                    case > 5:
+                        if ( name.Contains("rthon") )
+                        {
+                            includeRtHonourables = true;
+                        }
+                        break;
+                    case <= 5:
+                        includeRtHonourables = regularExpression.IsMatch(name);
+                        break;
+                }
 
-                if ( ( (nameTerm.Length<6) && (rtHon.Contains(nameTerm)) ) || ( (nameTerm.Length>5) && (nameTerm.Contains(rtHon)) ) ){
+                if (includeRtHonourables) {
                     query = query
                         .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!)
-                        .Contains(nameTerm)
-                        || x.RtHon.Equals(true));
+                        .Contains(name) || x.RtHon.Equals(true));
                 }
                 else {
                     query = query
                         .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!)
-                        .Contains(nameTerm));
+                        .Contains(name));
                 }
             }
 

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -1,23 +1,10 @@
-﻿using System;
-using System.Collections;
-using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
-using System.Diagnostics.Metrics;
-using System.Linq;
-using System.Net;
-using System.Net.NetworkInformation;
-using System.Reflection.Emit;
-using System.Text;  
-using System.Xml.Linq;
-using ChapsDotNET.Business.Exceptions;
+﻿using ChapsDotNET.Business.Exceptions;
 using ChapsDotNET.Business.Interfaces;
 using ChapsDotNET.Business.Models;
 using ChapsDotNET.Business.Models.Common;
 using ChapsDotNET.Data.Contexts;
 using ChapsDotNET.Data.Entities;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Primitives;
 
 namespace ChapsDotNET.Business.Components
 {
@@ -55,13 +42,9 @@ namespace ChapsDotNET.Business.Components
             else
             {
                 if ( !string.IsNullOrWhiteSpace(request.nameFilterTerm) ) {
-                    query = query.Where(
-                        x => (
-                            x.Salutation!.Detail??"".Concat(x.FirstNames!).Concat(x.Surname).Concat(x.Suffix!)
-                        )
-                        .ToString()
-                        .ToLower()
-                        .Contains(request.nameFilterTerm.ToLower())
+                    query = query
+                        .Where(x => (x.Salutation!.Detail + x.FirstNames + x.Surname + x.Suffix)
+                        .Contains(request.nameFilterTerm.Replace(" ", "").ToLower())
                     );
                 }
 

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -68,6 +68,18 @@ namespace ChapsDotNET.Business.Components
                     x => x.Email!.ToLower().Contains(request.emailFilterTerm.ToLower())
                 );
 			}
+            if (request.activeFilter == true)
+            {
+                query = query.Where(
+                    x => x.active.Equals(true)
+                );
+            }
+            if (request.activeFilter == false)
+            {
+                query = query.Where(
+                    x => x.active.Equals(false)
+                );
+            }
 
             // ----------------------------------------------------------------
 

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -35,9 +35,9 @@ namespace ChapsDotNET.Business.Components
 
             // Filtering
 
-            if (!string.IsNullOrWhiteSpace(request.nameFilterTerm)) {
+            if (!string.IsNullOrWhiteSpace(request.NameFilterTerm)) {
                 bool includeRtHonourables = false;
-                string name = request.nameFilterTerm.Replace(" ", "").ToLower();
+                string name = request.NameFilterTerm.Replace(" ", "").ToLower();
                 string characterPattern = "";
 
                 switch (name.Length)
@@ -76,22 +76,22 @@ namespace ChapsDotNET.Business.Components
                 }
             }
 
-            if (!string.IsNullOrWhiteSpace(request.addressFilterTerm))
+            if (!string.IsNullOrWhiteSpace(request.AddressFilterTerm))
             {
                 query = query
                     .Where(x => (x.AddressLine1! + x.AddressLine2! + x.AddressLine3! + x.Town! + x.County! + x.Postcode!).Replace(" ", "").ToLower()
-                    .Contains(request.addressFilterTerm.Replace(" ", "").ToLower())
+                    .Contains(request.AddressFilterTerm.Replace(" ", "").ToLower())
                 );
             }
 
-            if (!string.IsNullOrWhiteSpace(request.emailFilterTerm))
+            if (!string.IsNullOrWhiteSpace(request.EmailFilterTerm))
             {
                 query = query
                     .Where(x => x.Email!.ToLower()
-                    .Contains(request.emailFilterTerm.ToLower()));
+                    .Contains(request.EmailFilterTerm.ToLower()));
             }
 
-            if (request.activeFilter == true)
+            if (request.ActiveFilter == true)
             {
                 query = query
                     .Where(x => x.active.Equals(true));
@@ -128,11 +128,11 @@ namespace ChapsDotNET.Business.Components
 
             return new PagedResult<List<MPModel>>
             {
-                activeFilter = request.activeFilter,
-                addressFilterTerm = request.addressFilterTerm,
+                ActiveFilter = request.ActiveFilter,
+                AddressFilterTerm = request.AddressFilterTerm,
                 CurrentPage = request.PageNumber,
-                emailFilterTerm = request.emailFilterTerm,
-                nameFilterTerm = request.nameFilterTerm,
+                EmailFilterTerm = request.EmailFilterTerm,
+                NameFilterTerm = request.NameFilterTerm,
                 PageSize = request.PageSize,
                 Results = mpsList,
                 RowCount = count

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -1,4 +1,5 @@
-﻿using ChapsDotNET.Business.Exceptions;
+﻿using System.Text.RegularExpressions;
+using ChapsDotNET.Business.Exceptions;
 using ChapsDotNET.Business.Interfaces;
 using ChapsDotNET.Business.Models;
 using ChapsDotNET.Business.Models.Common;
@@ -32,10 +33,20 @@ namespace ChapsDotNET.Business.Components
 
             if (!string.IsNullOrWhiteSpace(request.nameFilterTerm))
             {
-                query = query
-                    .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!)
-                    .Contains(request.nameFilterTerm.Replace(" ", "").ToLower())
-                );
+                string nameTerm =  request.nameFilterTerm.Replace(" ", "").ToLower();
+                string rtHon = "rthon";
+
+                if ( ( (nameTerm.Length<6) && (rtHon.Contains(nameTerm)) ) || ( (nameTerm.Length>5) && (nameTerm.Contains(rtHon)) ) ){
+                    query = query
+                        .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!)
+                        .Contains(nameTerm)
+                        || x.RtHon.Equals(true));
+                }
+                else {
+                    query = query
+                        .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!)
+                        .Contains(nameTerm));
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(request.addressFilterTerm))

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -37,30 +37,41 @@ namespace ChapsDotNET.Business.Components
 
             if (!string.IsNullOrWhiteSpace(request.nameFilterTerm)) {
                 bool includeRtHonourables = false;
-                string characterPattern = @"/(rtho)|(thon)|(rth)|(tho)|(hon)|(rt)|(th)|(ho)|(on)|[rthon]/";
-                string name =  request.nameFilterTerm.Replace(" ", "").ToLower();
-                Regex regularExpression = new Regex(characterPattern);
-                
-                switch (name.Length) {
-                    case > 5:
-                        if ( name.Contains("rthon") )
-                        {
-                            includeRtHonourables = true;
-                        }
+                string name = request.nameFilterTerm.Replace(" ", "").ToLower();
+                string characterPattern = "";
+
+                switch (name.Length)
+                {
+                    case 1:
+                        characterPattern = @"[rthon]";
                         break;
-                    case <= 5:
-                        includeRtHonourables = regularExpression.IsMatch(name);
+                    case 2:
+                        characterPattern = @"(rt|th|ho|on)";
+                        break;
+                    case 3:
+                        characterPattern = @"(rth|tho|hon)";
+                        break;
+                    case 4:
+                        characterPattern = @"(rtho|thon)";
+                        break;
+                    default:
+                        characterPattern = @"(rthon)";
                         break;
                 }
 
-                if (includeRtHonourables) {
+                Regex isRtHonourable = new Regex(characterPattern);
+                includeRtHonourables = isRtHonourable.IsMatch(name);
+
+                if (includeRtHonourables)
+                {
                     query = query
-                        .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!)
+                        .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!).Replace(" ", "").ToLower()
                         .Contains(name) || x.RtHon.Equals(true));
                 }
-                else {
+                else
+                {
                     query = query
-                        .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!)
+                        .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!).Replace(" ", "").ToLower()
                         .Contains(name));
                 }
             }
@@ -68,7 +79,7 @@ namespace ChapsDotNET.Business.Components
             if (!string.IsNullOrWhiteSpace(request.addressFilterTerm))
             {
                 query = query
-                    .Where(x => (x.AddressLine1! + x.AddressLine2! + x.AddressLine3! + x.Town! + x.County! + x.Postcode!)
+                    .Where(x => (x.AddressLine1! + x.AddressLine2! + x.AddressLine3! + x.Town! + x.County! + x.Postcode!).Replace(" ", "").ToLower()
                     .Contains(request.addressFilterTerm.Replace(" ", "").ToLower())
                 );
             }

--- a/ChapsDotNET.Business/Components/MPComponent.cs
+++ b/ChapsDotNET.Business/Components/MPComponent.cs
@@ -4,6 +4,7 @@ using ChapsDotNET.Business.Models;
 using ChapsDotNET.Business.Models.Common;
 using ChapsDotNET.Data.Contexts;
 using ChapsDotNET.Data.Entities;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
 namespace ChapsDotNET.Business.Components
@@ -27,7 +28,6 @@ namespace ChapsDotNET.Business.Components
         {
             var query = _context.MPs.Include(x => x.Salutation).AsQueryable();
 
-
             // Filtering ------------------------------------------------------
 
             if (
@@ -37,38 +37,41 @@ namespace ChapsDotNET.Business.Components
                 request.activeFilter.Equals(null)
                 )
             {
-                    query = query.Where(x => x.active.Equals(true));
+                query = query.Where(x => x.active.Equals(true));
             }
             else
             {
-                if ( !string.IsNullOrWhiteSpace(request.nameFilterTerm) ) {
+                if (!string.IsNullOrWhiteSpace(request.nameFilterTerm))
+                {
                     query = query
-                        .Where(x => (x.Salutation!.Detail + x.FirstNames + x.Surname + x.Suffix)
+                        .Where(x => (x.Salutation!.Detail + x.FirstNames! + x.Surname + x.Suffix!)
                         .Contains(request.nameFilterTerm.Replace(" ", "").ToLower())
                     );
                 }
 
-                if ( !string.IsNullOrWhiteSpace(request.addressFilterTerm )) {
-                    query = query.Where(
-                        x => x.AddressLine1!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
-                        x.AddressLine2!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
-                        x.AddressLine3!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
-                        x.Town!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
-                        x.County!.ToLower().Contains(request.addressFilterTerm.ToLower()) ||
-                        x.Postcode!.ToLower().Contains(request.addressFilterTerm.ToLower())
+                if (!string.IsNullOrWhiteSpace(request.addressFilterTerm))
+                {
+                    query = query
+                        .Where(x => (x.AddressLine1! + x.AddressLine2! + x.AddressLine3! + x.Town! + x.County! + x.Postcode!)
+                        .Contains(request.addressFilterTerm.Replace(" ", "").ToLower())
                     );
                 }
 
-                if ( !string.IsNullOrWhiteSpace(request.emailFilterTerm) ) {
-                    query = query.Where( x => x.Email!.ToLower().Contains(request.emailFilterTerm.ToLower()) );
+                if (!string.IsNullOrWhiteSpace(request.emailFilterTerm))
+                {
+                    query = query
+                        .Where(x => x.Email!.ToLower()
+                        .Contains(request.emailFilterTerm.ToLower()));
                 }
 
-                if ( request.activeFilter == true ) {
-                    query = query.Where( x => x.active.Equals(true) );
+                if (request.activeFilter == true)
+                {
+                    query = query.Where(x => x.active.Equals(true));
                 }
 
-                if ( request.activeFilter == false ) {
-                    query = query.Where( x => x.active.Equals(false) );
+                if (request.activeFilter == false)
+                {
+                    query = query.Where(x => x.active.Equals(false));
                 }
             }
 

--- a/ChapsDotNET.Business/Interfaces/IMPComponent.cs
+++ b/ChapsDotNET.Business/Interfaces/IMPComponent.cs
@@ -10,5 +10,6 @@ namespace ChapsDotNET.Business.Interfaces
         Task<int> AddMPAsync(MPModel model);
         Task UpdateMPAsync(MPModel model);
         Task<MPModel> GetMPAsync(int id);
+        Task<string> DisplayFullName(int id);
     }
 }

--- a/ChapsDotNET.Business/Models/Common/MPRequestModel.cs
+++ b/ChapsDotNET.Business/Models/Common/MPRequestModel.cs
@@ -2,11 +2,11 @@
 {
     public class MPRequestModel : PagedRequest
     {
+        public bool activeFilter { get; set; } = true;
         public bool ShowActiveAndInactive { get; set; } = false;
-        public string nameFilterTerm { get; set; } = String.Empty;
         public string addressFilterTerm { get; set; } = String.Empty;
         public string emailFilterTerm { get; set; } = String.Empty;
+        public string nameFilterTerm { get; set; } = String.Empty;
         public string? sortOrder { get; set; }
-        public bool activeFilter { get; set; } = true;
     }
 }

--- a/ChapsDotNET.Business/Models/Common/MPRequestModel.cs
+++ b/ChapsDotNET.Business/Models/Common/MPRequestModel.cs
@@ -1,11 +1,13 @@
-﻿namespace ChapsDotNET.Business.Models.Common
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ChapsDotNET.Business.Models.Common
 {
     public class MPRequestModel : PagedRequest
     {
-        public bool activeFilter { get; set; } = true;
-        public string addressFilterTerm { get; set; } = String.Empty;
-        public string emailFilterTerm { get; set; } = String.Empty;
-        public string nameFilterTerm { get; set; } = String.Empty;
-        public string? sortOrder { get; set; }
+        public bool ActiveFilter { get; set; } = true;
+        public string? AddressFilterTerm { get; set; } = String.Empty;
+        public string? EmailFilterTerm { get; set; } = String.Empty;
+        public string? NameFilterTerm { get; set; } = String.Empty;
+        public string? SortOrder { get; set; }
     }
 }

--- a/ChapsDotNET.Business/Models/Common/MPRequestModel.cs
+++ b/ChapsDotNET.Business/Models/Common/MPRequestModel.cs
@@ -3,7 +3,6 @@
     public class MPRequestModel : PagedRequest
     {
         public bool activeFilter { get; set; } = true;
-        public bool ShowActiveAndInactive { get; set; } = false;
         public string addressFilterTerm { get; set; } = String.Empty;
         public string emailFilterTerm { get; set; } = String.Empty;
         public string nameFilterTerm { get; set; } = String.Empty;

--- a/ChapsDotNET.Business/Models/Common/PagedResult.cs
+++ b/ChapsDotNET.Business/Models/Common/PagedResult.cs
@@ -7,10 +7,10 @@
         public int PageCount => (int)Math.Ceiling((double)RowCount / PageSize);
         public int PageSize { get; set; }
         public int RowCount { get; set; }
-        public string? sortOrder { get; set; }
-        public string? nameFilterTerm { get; set; }
-        public string? addressFilterTerm { get; set; }
-        public string? emailFilterTerm { get; set; }
+        //public string? sortOrder { get; set; }
+        //public string? nameFilterTerm { get; set; }
+        //public string? addressFilterTerm { get; set; }
+        //public string? emailFilterTerm { get; set; }
         public bool activeFilter { get; set; }
     }
 

--- a/ChapsDotNET.Business/Models/Common/PagedResult.cs
+++ b/ChapsDotNET.Business/Models/Common/PagedResult.cs
@@ -1,4 +1,6 @@
-﻿namespace ChapsDotNET.Business.Models.Common
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ChapsDotNET.Business.Models.Common
 {
     public class PagedResult<T> : IPagedResult
     {
@@ -7,11 +9,11 @@
         public int PageCount => (int)Math.Ceiling((double)RowCount / PageSize);
         public int PageSize { get; set; }
         public int RowCount { get; set; }
-        public string? sortOrder { get; set; }
-        public string? nameFilterTerm { get; set; }
-        public string? addressFilterTerm { get; set; }
-        public string? emailFilterTerm { get; set; }
-        public bool activeFilter { get; set; }
+        public string? SortOrder { get; set; }
+        public string? AddressFilterTerm { get; set; } = String.Empty;
+        public string? EmailFilterTerm { get; set; } = String.Empty;
+        public string? NameFilterTerm { get; set; } = String.Empty;
+        public bool ActiveFilter { get; set; }
     }
 
     public interface IPagedResult

--- a/ChapsDotNET.Business/Models/Common/PagedResult.cs
+++ b/ChapsDotNET.Business/Models/Common/PagedResult.cs
@@ -7,10 +7,10 @@
         public int PageCount => (int)Math.Ceiling((double)RowCount / PageSize);
         public int PageSize { get; set; }
         public int RowCount { get; set; }
-        //public string? sortOrder { get; set; }
-        //public string? nameFilterTerm { get; set; }
-        //public string? addressFilterTerm { get; set; }
-        //public string? emailFilterTerm { get; set; }
+        public string? sortOrder { get; set; }
+        public string? nameFilterTerm { get; set; }
+        public string? addressFilterTerm { get; set; }
+        public string? emailFilterTerm { get; set; }
         public bool activeFilter { get; set; }
     }
 

--- a/ChapsDotNET.Business/Models/MPModel.cs
+++ b/ChapsDotNET.Business/Models/MPModel.cs
@@ -24,7 +24,7 @@ namespace ChapsDotNET.Business.Models
         public string? Town { get; set; }
         public virtual Salutation Salutation { get; set; } = default!;
         public string? DisplayFullName { get; set; }
-        public string? sortOrder { get; set; }
+        public string? SortOrder { get; set; }
 
         //builds the address with out spaces
         public virtual List<string> populatedLines

--- a/ChapsDotNET.Data/Entities/MP.cs
+++ b/ChapsDotNET.Data/Entities/MP.cs
@@ -9,6 +9,7 @@ namespace ChapsDotNET.Data.Entities
         public bool RtHon { get; set; }
         public int MPID { get; set; }
         public int? SalutationID { get; set; }
+        public virtual Salutation? Salutation{ get; set; }
         public string Surname { get; set; } = string.Empty;
         public string? AddressLine1 { get; set; }
         public string? AddressLine2 { get; set; }

--- a/ChapsDotNET.Tests/Areas/MPControllerTests.cs
+++ b/ChapsDotNET.Tests/Areas/MPControllerTests.cs
@@ -24,7 +24,7 @@ namespace ChapsDotNET.Tests.Areas
         //    var mockSalutationComponent = Substitute.For<ISalutationComponent>();
         //    mockMPComponent.GetMPsAsync(Arg.Any<MPRequestModel>()).Returns(
         //        new PagedResult<List<MPModel>>
-        //        {
+        //        {   
         //            Results = new List<MPModel>()
         //            {
         //                new MPModel
@@ -68,14 +68,14 @@ namespace ChapsDotNET.Tests.Areas
         //    var controller = new MPsController(mockMPComponent, mockSalutationComponent);
 
         //    // Act
-        //    var result = await controller.Index() as ViewResult;
+        //    var result = await controller.Index("", "", "", false, "") as ViewResult;
         //    var resultCount = result?.Model as List<MPModel>;
 
         //    // Assert
         //    await mockMPComponent.Received().GetMPsAsync(Arg.Any<MPRequestModel>());
         //    result.Should().NotBe(null);
         //    result.Should().BeOfType<ViewResult>();
-        //    resultCount?.Count.Should().Be(2);
+        //    resultCount?.Count.Should().Be(1);
         //}
 
         [Fact]

--- a/ChapsDotNET.Tests/Areas/MPControllerTests.cs
+++ b/ChapsDotNET.Tests/Areas/MPControllerTests.cs
@@ -15,68 +15,67 @@ namespace ChapsDotNET.Tests.Areas
 {
 	public class MPControllerTests
 	{
-        // TODO: fix test to incorporate filter references
-        //[Fact]
-        //public async Task WhenMPIndexPageIsCalledAListOfMPsShouldBeReturned()
-        //{
-        //    //Arrange
-        //    var mockMPComponent = Substitute.For<IMPComponent>();
-        //    var mockSalutationComponent = Substitute.For<ISalutationComponent>();
-        //    mockMPComponent.GetMPsAsync(Arg.Any<MPRequestModel>()).Returns(
-        //        new PagedResult<List<MPModel>>
-        //        {   
-        //            Results = new List<MPModel>()
-        //            {
-        //                new MPModel
-        //                {
-        //                    MPId = 1,
-        //                    RtHon = false,
-        //                    SalutationId = 3,
-        //                    Surname = "Janeway",
-        //                    FirstNames = "Katherine",
-        //                    Email = "kathrine.janeway@starfleet.com",
-        //                    AddressLine1 = "StarFleet HQ",
-        //                    AddressLine2 = "",
-        //                    AddressLine3 = "",
-        //                    Town = "San Francisco",
-        //                    County = "",
-        //                    Postcode = "XX33 Q45",
-        //                    Suffix = "PHD",
-        //                    Active = true
-        //                },
+        [Fact]
+        public async Task WhenMPIndexPageIsCalledAListOfInActiveMPsShouldBeReturned()
+        {
+            //Arrange
+            var mockMPComponent = Substitute.For<IMPComponent>();
+            var mockSalutationComponent = Substitute.For<ISalutationComponent>();
+            mockMPComponent.GetMPsAsync(Arg.Any<MPRequestModel>()).Returns(
+                new PagedResult<List<MPModel>>
+                {
+                    Results = new List<MPModel>()
+                    {
+                        new MPModel
+                        {
+                            MPId = 1,
+                            RtHon = false,
+                            SalutationId = 3,
+                            Surname = "Janeway",
+                            FirstNames = "Katherine",
+                            Email = "kathrine.janeway@starfleet.com",
+                            AddressLine1 = "StarFleet HQ",
+                            AddressLine2 = "",
+                            AddressLine3 = "",
+                            Town = "San Francisco",
+                            County = "",
+                            Postcode = "XX33 Q45",
+                            Suffix = "PHD",
+                            Active = true
+                        },
 
-        //                new MPModel
-        //                {
-        //                    MPId = 2,
-        //                    RtHon = true,
-        //                    SalutationId = 28,
-        //                    Surname = "Picard",
-        //                    FirstNames = "Jean Luc",
-        //                    Email = "j.picard@chateau-picard.com",
-        //                    AddressLine1 = "Chateau Picard",
-        //                    AddressLine2 = "Le Rue Dragon",
-        //                    AddressLine3 = "",
-        //                    Town = "Lyon",
-        //                    County = "Aquitane",
-        //                    Postcode = "NC17 C01",
-        //                    Suffix = "",
-        //                    Active = false
-        //                }
-        //            }
-        //        }
-        //    );
-        //    var controller = new MPsController(mockMPComponent, mockSalutationComponent);
+                        new MPModel
+                        {
+                            MPId = 2,
+                            RtHon = true,
+                            SalutationId = 28,
+                            Surname = "Picard",
+                            FirstNames = "Jean Luc",
+                            Email = "j.picard@chateau-picard.com",
+                            AddressLine1 = "Chateau Picard",
+                            AddressLine2 = "Le Rue Dragon",
+                            AddressLine3 = "",
+                            Town = "Lyon",
+                            County = "Aquitane",
+                            Postcode = "NC17 C01",
+                            Suffix = "",
+                            Active = false
+                        }
+                    }
+                }
+            );
+            var controller = new MPsController(mockMPComponent, mockSalutationComponent);
 
-        //    // Act
-        //    var result = await controller.Index("", "", "", false, "") as ViewResult;
-        //    var resultCount = result?.Model as List<MPModel>;
+            // Act
+            var result = await controller.Index("", "", "", false, "") as ViewResult;
+            var resultCount = result?.Model as List<MPModel>;
 
-        //    // Assert
-        //    await mockMPComponent.Received().GetMPsAsync(Arg.Any<MPRequestModel>());
-        //    result.Should().NotBe(null);
-        //    result.Should().BeOfType<ViewResult>();
-        //    resultCount?.Count.Should().Be(1);
-        //}
+            // Assert
+            await mockMPComponent.Received().GetMPsAsync(Arg.Any<MPRequestModel>());
+            result.Should().NotBe(null);
+            result.Should().BeOfType<ViewResult>();
+            resultCount?.Count.Should().Be(1);
+        }
 
         [Fact]
         public async Task WhenCreateMethodIsCalledTheCreateViewIsReturned()

--- a/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
+++ b/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
@@ -27,13 +27,13 @@ namespace ChapsDotNET.Areas.Admin.Controllers
         public async Task<IActionResult> Index(string nameFilterTerm, string addressFilterTerm, string emailFilterTerm, bool activeFilter, string sortOrder, int page = 1)
         {
             var pagedResult = await _mpComponent.GetMPsAsync(new MPRequestModel {
+                    activeFilter = activeFilter,
+                    addressFilterTerm = addressFilterTerm,
+                    emailFilterTerm = emailFilterTerm,
+                    nameFilterTerm = nameFilterTerm,
                     PageNumber = page,
                     PageSize = 20,
                     ShowActiveAndInactive = true,
-                    nameFilterTerm = nameFilterTerm,
-                    addressFilterTerm = addressFilterTerm,
-                    emailFilterTerm = emailFilterTerm,
-                    activeFilter = activeFilter,
                     sortOrder = sortOrder
             } );
 

--- a/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
+++ b/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
@@ -27,10 +27,10 @@ namespace ChapsDotNET.Areas.Admin.Controllers
         public async Task<IActionResult> Index(string nameFilterTerm, string addressFilterTerm, string emailFilterTerm, bool activeFilter, string sortOrder, int page = 1)
         {
             var pagedResult = await _mpComponent.GetMPsAsync(new MPRequestModel {
-                    activeFilter = activeFilter,
+                    nameFilterTerm = nameFilterTerm,
                     addressFilterTerm = addressFilterTerm,
                     emailFilterTerm = emailFilterTerm,
-                    nameFilterTerm = nameFilterTerm,
+                    activeFilter = activeFilter,  
                     PageNumber = page,
                     PageSize = 20,
                     ShowActiveAndInactive = true,
@@ -122,7 +122,6 @@ namespace ChapsDotNET.Areas.Admin.Controllers
             nameParts.Add(mp.Suffix != null ? mp.Suffix : null!);
 
             return string.Join(" ", nameParts.Where(s => !string.IsNullOrEmpty(s)));
-
         }
     }
 }

--- a/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
+++ b/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
@@ -33,7 +33,6 @@ namespace ChapsDotNET.Areas.Admin.Controllers
                     activeFilter = activeFilter,  
                     PageNumber = page,
                     PageSize = 20,
-                    ShowActiveAndInactive = true,
                     sortOrder = sortOrder
             } );
 
@@ -41,7 +40,7 @@ namespace ChapsDotNET.Areas.Admin.Controllers
             {
                 if (item != null)
                 {
-                    item.DisplayFullName = DisplayFullName(item.MPId).Result;
+                    item.DisplayFullName = _mpComponent.DisplayFullName(item.MPId).Result;
                 }
             }
             return View(pagedResult);
@@ -93,35 +92,6 @@ namespace ChapsDotNET.Areas.Admin.Controllers
         {
             await _mpComponent.UpdateMPAsync(viewModel.ToModel());
             return RedirectToAction("index");
-        }
-
-        public async Task<string> DisplayFullName(int id)
-        {
-            var mpmodel = await _mpComponent.GetMPAsync(id);
-            var mp = mpmodel.ToViewModel();
-            string? salutation = null;
-            if (mp.SalutationId != null)
-            {
-                salutation = _salutationComponent.GetSalutationAsync((int)mp.SalutationId).Result.Detail;
-            }
-            else
-            {
-                salutation = String.Empty;
-            }
-           
-            List<string> nameParts = new List<string>();
-
-            if (mp.RtHon == true)
-            {
-                nameParts.Add("Rt Hon");
-            }
-
-            nameParts.Add(salutation!);
-            nameParts.Add(mp.FirstNames != null ? mp.FirstNames : null!);
-            nameParts.Add(mp.Surname);
-            nameParts.Add(mp.Suffix != null ? mp.Suffix : null!);
-
-            return string.Join(" ", nameParts.Where(s => !string.IsNullOrEmpty(s)));
         }
     }
 }

--- a/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
+++ b/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
@@ -24,16 +24,16 @@ namespace ChapsDotNET.Areas.Admin.Controllers
             _salutationComponent = salutationComponent;
         }
 
-        public async Task<IActionResult> Index(string nameFilterTerm, string addressFilterTerm, string emailFilterTerm, bool activeFilter, string sortOrder, int page = 1)
+        public async Task<IActionResult> Index(string NameFilterTerm, string AddressFilterTerm, string EmailFilterTerm, bool ActiveFilter, string SortOrder, int page = 1)
         {
             var pagedResult = await _mpComponent.GetMPsAsync(new MPRequestModel {
-                    nameFilterTerm = nameFilterTerm,
-                    addressFilterTerm = addressFilterTerm,
-                    emailFilterTerm = emailFilterTerm,
-                    activeFilter = activeFilter,
+                    NameFilterTerm = NameFilterTerm,
+                    AddressFilterTerm = AddressFilterTerm,
+                    EmailFilterTerm = EmailFilterTerm,
+                    ActiveFilter = ActiveFilter,
                     PageNumber = page,
                     PageSize = 20,
-                    sortOrder = sortOrder
+                    SortOrder = SortOrder
             } );
 
             foreach (var item in pagedResult.Results!)

--- a/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
+++ b/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
@@ -113,7 +113,7 @@ namespace ChapsDotNET.Areas.Admin.Controllers
 
             if (mp.RtHon == true)
             {
-                nameParts.Add("RtHon");
+                nameParts.Add("Rt Hon");
             }
 
             nameParts.Add(salutation!);

--- a/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
+++ b/ChapsDotNET/Areas/Admin/Controllers/MPsController.cs
@@ -30,7 +30,7 @@ namespace ChapsDotNET.Areas.Admin.Controllers
                     nameFilterTerm = nameFilterTerm,
                     addressFilterTerm = addressFilterTerm,
                     emailFilterTerm = emailFilterTerm,
-                    activeFilter = activeFilter,  
+                    activeFilter = activeFilter,
                     PageNumber = page,
                     PageSize = 20,
                     sortOrder = sortOrder

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -24,7 +24,7 @@
 
 <div class="flex-container">
     <section class="filters">
-        @using (Html.BeginForm(null, null, FormMethod.Post, new { @class = "filter" }))
+        @using (Html.BeginForm(null, null, FormMethod.Get, new { @class = "filter" }))
         {
             <fieldset>
                 <legend class="caption">
@@ -38,21 +38,21 @@
                     @Html.Editor("nameFilterTerm", null)
                 </div>
 
-                <label class="editor-label" for="addressFilterTerm">
-                    Address contains
-                </label>
-                <div class="editor-field">
-                    @Html.Editor("addressFilterTerm", null)
-                </div>
+                @*<label class="editor-label" for="addressFilterTerm">
+            Address contains
+        </label>
+        <div class="editor-field">
+            @Html.Editor("addressFilterTerm", null)
+        </div>
 
-                <label class="editor-label" for="emailFilterTerm">
-                    Email address contains
-                </label>
-                <div class="editor-field">
-                    @Html.Editor("emailFilterTerm", null)
-                </div>
+        <label class="editor-label" for="emailFilterTerm">
+            Email address contains
+        </label>
+        <div class="editor-field">
+            @Html.Editor("emailFilterTerm", null)
+        </div>*@
 
-                <input alt="Filter MPs" name="filter" type="submit" value="Apply filter" />
+                <button alt="Filter MPs" type="submit">Apply filter</button>
 
             </fieldset>
         }
@@ -102,7 +102,7 @@
             </tbody>
         </table>
         <div class="pagination">
-            @Html.PageLinks(@Model, x => Url.Action("Index", new { page = x.ToString() }))
+            @Html.PageLinks(@Model, x => Url.Action("Index", new { page = x.ToString(), nameFilterTerm = "smith" }))
         </div>
     </section>
 </div>

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -52,7 +52,7 @@
                     @Html.Editor("emailFilterTerm", null)
                 </div>
 
-                <input alt="Filter MPs" type="submit" value="Apply filters" />
+                <input alt="Filter MPs" name="filter" type="submit" value="Apply filter" />
 
             </fieldset>
         }

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -53,17 +53,17 @@
                 </div>
 
                 <label class="editor-label" for="activeFilter">
-                    Only active
+                    Active only
                 </label>
                 <div class="editor-field">
                     @Html.CheckBox("activeFilter", null)
                 </div>
 
-                @Html.Hidden("sortOrder", null)
+                @*@Html.Hidden("sortOrder", null)*@
 
                 <button alt="Filter MPs" type="submit">Apply filter</button>
 
-                <a href="" class="reset">Clear filters</a>
+                <input type="reset" value="Clear filters" />
 
             </fieldset>
         }
@@ -113,7 +113,17 @@
             </tbody>
         </table>
         <div class="pagination">
-            @Html.PageLinks(@Model, x => Url.Action("Index", new { page = x.ToString(), nameFilterTerm = "smith" }))
+            @Html.PageLinks(
+                @Model, x => Url.Action(
+                    "Index", new {
+                        page = x.ToString(),
+                        nameFilterTerm = Model.nameFilterTerm,
+                        addressFilterTerm = Model.addressFilterTerm,
+                        emailFilterTerm = Model.emailFilterTerm,
+                        activeFilter = Model.activeFilter
+                    }
+                )
+            )
         </div>
     </section>
 </div>

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -24,42 +24,41 @@
 
 <div class="flex-container">
     <section class="filters">
-        @using (Html.BeginForm(null, null, FormMethod.Get, new { @class = "filter" }))
-        {
+        @using (Html.BeginForm(null, null, FormMethod.Get, new { @class = "filter", novalidate = "novalidate" }))
+            {
             <fieldset>
                 <legend class="caption">
                     Filter
                 </legend>
-
-                <label class="editor-label" for="nameFilterTerm">
+                <label class="editor-label" for="NameFilterTerm">
                     Name contains:
                 </label>
                 <div class="editor-field">
-                    @Html.Editor("nameFilterTerm", null)
+                    @Html.EditorFor( model => model.NameFilterTerm, new { htmlAttributes = new { AccessKey = "F" } } )
                 </div>
 
-                <label class="editor-label" for="addressFilterTerm">
+                <label class="editor-label" for="AddressFilterTerm">
                     Address contains
                 </label>
                 <div class="editor-field">
-                    @Html.Editor("addressFilterTerm", null)
+                    @Html.EditorFor(model => model.AddressFilterTerm, new { htmlAttributes = new { AccessKey = "F" } })
                 </div>
 
-                <label class="editor-label" for="emailFilterTerm">
+                <label class="editor-label" for="EmailFilterTerm">
                     Email address contains
                 </label>
                 <div class="editor-field">
-                    @Html.Editor("emailFilterTerm", null)
+                    @Html.EditorFor(model => model.EmailFilterTerm, new { htmlAttributes = new { AccessKey = "F" } })
                 </div>
 
-                <label class="editor-label" for="activeFilter">
+                <label class="editor-label" for="ActiveFilter">
                     Active only
                 </label>
                 <div class="editor-field">
-                    @Html.CheckBox("activeFilter", null)
+                    @Html.CheckBoxFor(model => model.ActiveFilter, new { htmlAttributes = new { AccessKey = "F" } })
                 </div>
 
-                @*@Html.Hidden("sortOrder", null)*@
+                @*@Html.Hidden("SortOrder", null)*@
 
                 <button alt="Filter MPs" type="submit">Apply filter</button>
 
@@ -120,10 +119,10 @@
                         "Index", new
                              {
                             page = x.ToString(),
-                            nameFilterTerm = Model.nameFilterTerm,
-                            addressFilterTerm = Model.addressFilterTerm,
-                            emailFilterTerm = Model.emailFilterTerm,
-                            activeFilter = Model.activeFilter
+                            NameFilterTerm = Model.NameFilterTerm,
+                            AddressFilterTerm = Model.AddressFilterTerm,
+                            EmailFilterTerm = Model.EmailFilterTerm,
+                            ActiveFilter = Model.ActiveFilter
                         }
                     )
                 )

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -63,7 +63,7 @@
 
                 <button alt="Filter MPs" type="submit">Apply filter</button>
 
-                <input type="reset" value="Clear filters" />
+                <a class="reset" href="">Clear filters</a>
 
             </fieldset>
         }

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -38,21 +38,32 @@
                     @Html.Editor("nameFilterTerm", null)
                 </div>
 
-                @*<label class="editor-label" for="addressFilterTerm">
-            Address contains
-        </label>
-        <div class="editor-field">
-            @Html.Editor("addressFilterTerm", null)
-        </div>
+                <label class="editor-label" for="addressFilterTerm">
+                    Address contains
+                </label>
+                <div class="editor-field">
+                    @Html.Editor("addressFilterTerm", null)
+                </div>
 
-        <label class="editor-label" for="emailFilterTerm">
-            Email address contains
-        </label>
-        <div class="editor-field">
-            @Html.Editor("emailFilterTerm", null)
-        </div>*@
+                <label class="editor-label" for="emailFilterTerm">
+                    Email address contains
+                </label>
+                <div class="editor-field">
+                    @Html.Editor("emailFilterTerm", null)
+                </div>
+
+                <label class="editor-label" for="activeFilter">
+                    Only active
+                </label>
+                <div class="editor-field">
+                    @Html.CheckBox("activeFilter", null)
+                </div>
+
+                @Html.Hidden("sortOrder", null)
 
                 <button alt="Filter MPs" type="submit">Apply filter</button>
+
+                <a href="" class="reset">Clear filters</a>
 
             </fieldset>
         }
@@ -62,6 +73,7 @@
             <caption class="caption">Members of Parliament</caption>
             <thead>
                 <tr>
+
                     <th scope="col">
                         Name
                     </th>
@@ -74,6 +86,43 @@
                     <th scope="col">
                         Active
                     </th>
+
+                    @*<th scope="col" aria-sort="ascending">
+                        @using (Html.BeginForm(null, null, FormMethod.Get, new { @class = "tableSort" }))
+                        {
+                            @Html.Hidden("activeFilter", null)
+                            @Html.Hidden("addressFilterTerm", null)
+                            @Html.Hidden("emailFilterTerm", null)
+                            @Html.Hidden("nameFilterTerm", null)
+                            @Html.Hidden("sortOrder", "name asc")
+                            <button id="name" data-index="0" name="sortOrder" type="submit" value="name">Name</button>
+                        }
+                    </th>
+                    <th scope="col" aria-sort="none">
+                        @using (Html.BeginForm(null, null, FormMethod.Get, new { @class = "tableSort" }))
+                        {
+                            @Html.Hidden("activeFilter", null)
+                            @Html.Hidden("addressFilterTerm", null)
+                            @Html.Hidden("emailFilterTerm", null)
+                            @Html.Hidden("nameFilterTerm", null)
+                            @Html.Hidden("sortOrder", "address asc")
+                            <button id="address" data-index="1" name="sortOrder" type="submit" value="address">Address</button>
+                        }
+                    </th>
+                    <th scope="col" aria-sort="none">
+                        @using (Html.BeginForm(null, null, FormMethod.Get, new { @class = "tableSort" }))
+                        {
+                            @Html.Hidden("activeFilter", null)
+                            @Html.Hidden("addressFilterTerm", null)
+                            @Html.Hidden("emailFilterTerm", null)
+                            @Html.Hidden("nameFilterTerm", null)
+                            @Html.Hidden("sortOrder", "email asc")
+                            <button id="email" data-index="2" name="sortOrder" type="submit" value="email">Email</button>
+                        }
+                    </th>
+                    <th scope="col">
+                        Active
+                    </th>*@
                 </tr>
             </thead>
             <tbody>

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -24,8 +24,8 @@
 
 <div class="flex-container">
     <section class="filters">
-        @using (Html.BeginForm())
-        {
+        @using (Html.BeginForm(null, null, FormMethod.Post, new { @class = "filter" }))
+            {
             <fieldset>
                 <legend class="caption">
                     Filter

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -131,7 +131,9 @@
         }
         else
         {
-            <h3 class="error">No records matched your filter criteria</h3>
+            <div class="alert comment">
+                <span class="comment">No records matched your criteria</span>
+            </div>
         }
     </section>
 </div>

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -86,43 +86,6 @@
                     <th scope="col">
                         Active
                     </th>
-
-                    @*<th scope="col" aria-sort="ascending">
-                        @using (Html.BeginForm(null, null, FormMethod.Get, new { @class = "tableSort" }))
-                        {
-                            @Html.Hidden("activeFilter", null)
-                            @Html.Hidden("addressFilterTerm", null)
-                            @Html.Hidden("emailFilterTerm", null)
-                            @Html.Hidden("nameFilterTerm", null)
-                            @Html.Hidden("sortOrder", "name asc")
-                            <button id="name" data-index="0" name="sortOrder" type="submit" value="name">Name</button>
-                        }
-                    </th>
-                    <th scope="col" aria-sort="none">
-                        @using (Html.BeginForm(null, null, FormMethod.Get, new { @class = "tableSort" }))
-                        {
-                            @Html.Hidden("activeFilter", null)
-                            @Html.Hidden("addressFilterTerm", null)
-                            @Html.Hidden("emailFilterTerm", null)
-                            @Html.Hidden("nameFilterTerm", null)
-                            @Html.Hidden("sortOrder", "address asc")
-                            <button id="address" data-index="1" name="sortOrder" type="submit" value="address">Address</button>
-                        }
-                    </th>
-                    <th scope="col" aria-sort="none">
-                        @using (Html.BeginForm(null, null, FormMethod.Get, new { @class = "tableSort" }))
-                        {
-                            @Html.Hidden("activeFilter", null)
-                            @Html.Hidden("addressFilterTerm", null)
-                            @Html.Hidden("emailFilterTerm", null)
-                            @Html.Hidden("nameFilterTerm", null)
-                            @Html.Hidden("sortOrder", "email asc")
-                            <button id="email" data-index="2" name="sortOrder" type="submit" value="email">Email</button>
-                        }
-                    </th>
-                    <th scope="col">
-                        Active
-                    </th>*@
                 </tr>
             </thead>
             <tbody>

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -25,7 +25,7 @@
 <div class="flex-container">
     <section class="filters">
         @using (Html.BeginForm(null, null, FormMethod.Post, new { @class = "filter" }))
-            {
+        {
             <fieldset>
                 <legend class="caption">
                     Filter

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -22,50 +22,87 @@
     @Html.ActionLink("Add a new member of Parliament", "Create", "MPs")
 </div>
 
-<table class="withSort">
-    <caption class="caption">Members of Parliament</caption>
-    <thead>
-        <tr>
-            <th scope="col">
-                Name
-            </th>
-            <th scope="col">
-                Address
-            </th>
-            <th scope="col">
-                Email
-            </th>
-            <th scope="col">
-                Active
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var mp in Model.Results!.ToList())
+<div class="flex-container">
+    <section class="filters">
+        @using (Html.BeginForm())
         {
-            <tr>
-                <td>
-                    <a href="/Admin/MPs/Edit/@mp.MPId">
-                        @Html.DisplayFor(modelItem => mp.DisplayFullName)
-                    </a>
-                </td>
-                <td>
-                    @Html.DisplayFor(modelItem => mp.DisplaySingleLineAddress)
-                </td>
-                <td>
-                    @if (!string.IsNullOrWhiteSpace(mp.Email))
-                    {
-                        @Html.DisplayFor(x => mp.Email)
-                    }
-                </td>
-                <td align="center">
-                    @Html.DisplayFor(x => mp.Active)
-                </td>
-            </tr>
-        }
-    </tbody>
-</table>
+            <fieldset>
+                <legend class="caption">
+                    Filter
+                </legend>
 
-<div class="pagination">
-    @Html.PageLinks(@Model, x => Url.Action("Index", new { page = x.ToString() }))
+                <label class="editor-label" for="nameFilterTerm">
+                    Name contains:
+                </label>
+                <div class="editor-field">
+                    @Html.Editor("nameFilterTerm", null)
+                </div>
+
+                <label class="editor-label" for="addressFilterTerm">
+                    Address contains
+                </label>
+                <div class="editor-field">
+                    @Html.Editor("addressFilterTerm", null)
+                </div>
+
+                <label class="editor-label" for="emailFilterTerm">
+                    Email address contains
+                </label>
+                <div class="editor-field">
+                    @Html.Editor("emailFilterTerm", null)
+                </div>
+
+                <input alt="Filter MPs" type="submit" value="Apply filters" />
+
+            </fieldset>
+        }
+    </section>
+    <section class="mainContent">
+        <table class="withSort">
+            <caption class="caption">Members of Parliament</caption>
+            <thead>
+                <tr>
+                    <th scope="col">
+                        Name
+                    </th>
+                    <th scope="col">
+                        Address
+                    </th>
+                    <th scope="col">
+                        Email
+                    </th>
+                    <th scope="col">
+                        Active
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var mp in Model.Results!.ToList())
+                {
+                    <tr>
+                        <td>
+                            <a href="/Admin/MPs/Edit/@mp.MPId">
+                                @Html.DisplayFor(modelItem => mp.DisplayFullName)
+                            </a>
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => mp.DisplaySingleLineAddress)
+                        </td>
+                        <td>
+                            @if (!string.IsNullOrWhiteSpace(mp.Email))
+                            {
+                                @Html.DisplayFor(x => mp.Email)
+                            }
+                        </td>
+                        <td align="center">
+                            @Html.DisplayFor(x => mp.Active)
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+        <div class="pagination">
+            @Html.PageLinks(@Model, x => Url.Action("Index", new { page = x.ToString() }))
+        </div>
+    </section>
 </div>

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -69,61 +69,69 @@
         }
     </section>
     <section class="mainContent">
-        <table class="withSort">
-            <caption class="caption">Members of Parliament</caption>
-            <thead>
-                <tr>
-                    <th scope="col">
-                        Name
-                    </th>
-                    <th scope="col">
-                        Address
-                    </th>
-                    <th scope="col">
-                        Email
-                    </th>
-                    <th scope="col">
-                        Active
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var mp in Model.Results!.ToList())
-                {
+        @if (Model.Results!.Count > 0)
+        {
+            <table class="withSort">
+                <caption class="caption">Members of Parliament</caption>
+                <thead>
                     <tr>
-                        <td>
-                            <a href="/Admin/MPs/Edit/@mp.MPId">
-                                @Html.DisplayFor(modelItem => mp.DisplayFullName)
-                            </a>
-                        </td>
-                        <td>
-                            @Html.DisplayFor(modelItem => mp.DisplaySingleLineAddress)
-                        </td>
-                        <td>
-                            @if (!string.IsNullOrWhiteSpace(mp.Email))
-                            {
-                                @Html.DisplayFor(x => mp.Email)
-                            }
-                        </td>
-                        <td align="center">
-                            @Html.DisplayFor(x => mp.Active)
-                        </td>
+                        <th scope="col">
+                            Name
+                        </th>
+                        <th scope="col">
+                            Address
+                        </th>
+                        <th scope="col">
+                            Email
+                        </th>
+                        <th scope="col">
+                            Active
+                        </th>
                     </tr>
-                }
-            </tbody>
-        </table>
-        <div class="pagination">
-            @Html.PageLinks(
-                @Model, x => Url.Action(
-                    "Index", new {
-                        page = x.ToString(),
-                        nameFilterTerm = Model.nameFilterTerm,
-                        addressFilterTerm = Model.addressFilterTerm,
-                        emailFilterTerm = Model.emailFilterTerm,
-                        activeFilter = Model.activeFilter
+                </thead>
+                <tbody>
+                    @foreach (var mp in Model.Results!.ToList())
+                    {
+                        <tr>
+                            <td>
+                                <a href="/Admin/MPs/Edit/@mp.MPId">
+                                    @Html.DisplayFor(modelItem => mp.DisplayFullName)
+                                </a>
+                            </td>
+                            <td>
+                                @Html.DisplayFor(modelItem => mp.DisplaySingleLineAddress)
+                            </td>
+                            <td>
+                                @if (!string.IsNullOrWhiteSpace(mp.Email))
+                                {
+                                    @Html.DisplayFor(x => mp.Email)
+                                }
+                            </td>
+                            <td align="center">
+                                @Html.DisplayFor(x => mp.Active)
+                            </td>
+                        </tr>
                     }
+                </tbody>
+            </table>
+            <div class="pagination">
+                @Html.PageLinks(
+                    @Model, x => Url.Action(
+                        "Index", new
+                             {
+                            page = x.ToString(),
+                            nameFilterTerm = Model.nameFilterTerm,
+                            addressFilterTerm = Model.addressFilterTerm,
+                            emailFilterTerm = Model.emailFilterTerm,
+                            activeFilter = Model.activeFilter
+                        }
+                    )
                 )
-            )
-        </div>
+            </div>
+        }
+        else
+        {
+            <h3 class="error">No records matched your filter criteria</h3>
+        }
     </section>
 </div>

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -73,7 +73,6 @@
             <caption class="caption">Members of Parliament</caption>
             <thead>
                 <tr>
-
                     <th scope="col">
                         Name
                     </th>

--- a/ChapsDotNET/Models/MPViewModel.cs
+++ b/ChapsDotNET/Models/MPViewModel.cs
@@ -49,6 +49,6 @@ namespace ChapsDotNET.Models
         public bool Active { get; set; }
         public SelectList SalutationList { get; set; } = default!;
         public string? DisplayFullName { get; set; }
-        public string? sortOrder { get; set; }
+        public string? SortOrder { get; set; }
     }
 }

--- a/ChapsDotNET/wwwroot/javascripts/chaps.js
+++ b/ChapsDotNET/wwwroot/javascripts/chaps.js
@@ -85,54 +85,54 @@
     $(document).ready(function () {
 
 
-        if ($(document.body).has('form')) {
+        //if ($(document.body).has('form')) {
 
-            if ($('form').hasClass('filter')) {
+        //    if ($('form').hasClass('filter')) {
 
-                if (typeof (Storage) !== "undefined") {
+        //        if (typeof (Storage) !== "undefined") {
 
-                    if ((sessionStorage.lastInputId === undefined) && (sessionStorage.lastInputValue === undefined)) {
-                        sessionStorage.lastInputId = "none";
-                        sessionStorage.lastInputValue = "none";
-                    }
+        //            if ((sessionStorage.lastInputId === undefined) && (sessionStorage.lastInputValue === undefined)) {
+        //                sessionStorage.lastInputId = "none";
+        //                sessionStorage.lastInputValue = "none";
+        //            }
 
-                    $('form.filter').on('change paste', function (event) {
-                        switch ($(event.target).attr('id')) {                            
-                            case 'addressFilterTerm':
-                                $('#emailFilterTerm, #nameFilterTerm').val('');
-                                sessionStorage.lastInputValue = $('#addressFilterTerm').val();
-                                break;
-                            case 'emailFilterTerm':
-                                $('#addressFilterTerm, #nameFilterTerm').val('');
-                                sessionStorage.lastInputValue = $('#emailFilterTerm').val();
-                                break;
-                            case 'nameFilterTerm':
-                                $('#addressFilterTerm, #emailFilterTerm').val('');
-                                sessionStorage.lastInputValue = $('#nameFilterTerm').val();
-                                break;
-                        }
+        //            $('form.filter').on('change paste', function (event) {
+        //                switch ($(event.target).attr('id')) {                            
+        //                    case 'addressFilterTerm':
+        //                        $('#emailFilterTerm, #nameFilterTerm').val('');
+        //                        sessionStorage.lastInputValue = $('#addressFilterTerm').val();
+        //                        break;
+        //                    case 'emailFilterTerm':
+        //                        $('#addressFilterTerm, #nameFilterTerm').val('');
+        //                        sessionStorage.lastInputValue = $('#emailFilterTerm').val();
+        //                        break;
+        //                    case 'nameFilterTerm':
+        //                        $('#addressFilterTerm, #emailFilterTerm').val('');
+        //                        sessionStorage.lastInputValue = $('#nameFilterTerm').val();
+        //                        break;
+        //                }
 
-                        sessionStorage.lastInputId = $(event.target).attr('id');
-                    });
-                }
-            }
-        }
+        //                sessionStorage.lastInputId = $(event.target).attr('id');
+        //            });
+        //        }
+        //    }
+        //}
         // ----------------------------------------------------------------
 
         // ---- Form valuidations -----------------------------------------
 
         $('form').submit(function (event) {
 
-            if ($(event.target).has('form .filter')) {
-                console.log("this is a filter form");
+            //if ($(event.target).has('form .filter')) {
+            //    console.log("this is a filter form");
 
-                //document.cookie = “lastInputId = ' +  + ";" path = /Admin/MPs /; secrure”;
-                //document.cookie = “lastInputValue = ; path = /Admin/MPs /; secrure”;
+            //    //document.cookie = “lastInputId = ' +  + ";" path = /Admin/MPs /; secrure”;
+            //    //document.cookie = “lastInputValue = ; path = /Admin/MPs /; secrure”;
 
-                // TODO: move the session storage assignment to here!
-                // sessionStorage.lastInputId = $(event.target).attr('id');
-                // sessionStorage.lastInputValue = $(event.target).val();
-            }
+            //    // TODO: move the session storage assignment to here!
+            //    // sessionStorage.lastInputId = $(event.target).attr('id');
+            //    // sessionStorage.lastInputValue = $(event.target).val();
+            //}
 
             if ($(event.target).has('input .future-date')) {
                 if ($('#Date').val() < tomorrowsDate) {

--- a/ChapsDotNET/wwwroot/javascripts/chaps.js
+++ b/ChapsDotNET/wwwroot/javascripts/chaps.js
@@ -81,31 +81,25 @@
         $('span.counter').html(counterMsg);
     }
 
+    var hasQueryParams = function (url) {
+        return url.indexOf('?') !== -1;
+    }
+
     //  +---------------------------------------------------------------------------+
 
     $(document).ready(function () {
 
-
-        if ($(document.body).has('form')) {
-            if ($('form').hasClass('filter')) {
-            }
-        }
-
-        // Form listeners ----------------------------------------------------------------
-
-        $('a.reset').click(function () {
-            $('.filer :input').not(':button, :submit, :reset, :hidden, :checkbox, :radio').val('');
-            $('.filter :checkbox, :radio').prop('checked', false);
-        });
+        //if ( $(document.body).has('form') ) {
+        //    if ( $('form').hasClass('filter') ) {
+        //        if ($(this).find(":checkbox#activeFilter") && hasQueryParams(window.location.href) == false ) {
+        //            $('input#activeFilter').prop("checked", true);
+        //        }
+        //    }
+        //}
 
         // ---- Form validations -----------------------------------------
 
         $('form').submit(function (event) {
-
-            if ($(event.target).has('form .filter')) {
-                console.log("this is a filter form");
-            }
-
             if ($(event.target).has('input .future-date')) {
                 if ($('#Date').val() < tomorrowsDate) {
                     displayPastDateError();
@@ -115,7 +109,6 @@
                     return true;
                 }
             }
-
         });
 
         // --- Character counter -------------------------------------------

--- a/ChapsDotNET/wwwroot/javascripts/chaps.js
+++ b/ChapsDotNET/wwwroot/javascripts/chaps.js
@@ -12,6 +12,7 @@
 
     var yearMonthDayFormat = function (rawDate) {
         // returns date in yyyy-MM-dd format
+
         return rawDate.toISOString().slice(0, 10);
     }
 
@@ -85,59 +86,25 @@
     $(document).ready(function () {
 
 
-        //if ($(document.body).has('form')) {
+        if ($(document.body).has('form')) {
+            if ($('form').hasClass('filter')) {
+            }
+        }
 
-        //    if ($('form').hasClass('filter')) {
-
-        //        if (typeof (Storage) !== "undefined") {
-
-        //            if ((sessionStorage.lastInputId === undefined) && (sessionStorage.lastInputValue === undefined)) {
-        //                sessionStorage.lastInputId = "none";
-        //                sessionStorage.lastInputValue = "none";
-        //            }
-
-        //            $('form.filter').on('change paste', function (event) {
-        //                switch ($(event.target).attr('id')) {                            
-        //                    case 'addressFilterTerm':
-        //                        $('#emailFilterTerm, #nameFilterTerm').val('');
-        //                        sessionStorage.lastInputValue = $('#addressFilterTerm').val();
-        //                        break;
-        //                    case 'emailFilterTerm':
-        //                        $('#addressFilterTerm, #nameFilterTerm').val('');
-        //                        sessionStorage.lastInputValue = $('#emailFilterTerm').val();
-        //                        break;
-        //                    case 'nameFilterTerm':
-        //                        $('#addressFilterTerm, #emailFilterTerm').val('');
-        //                        sessionStorage.lastInputValue = $('#nameFilterTerm').val();
-        //                        break;
-        //                }
-
-        //                sessionStorage.lastInputId = $(event.target).attr('id');
-        //            });
-        //        }
-        //    }
-        //}
-        // ----------------------------------------------------------------
+        // Form listeners ----------------------------------------------------------------
 
         $('a.reset').click(function () {
-            var form = $(this).parents('form');
-            form.trigger("reset");
+            $('.filer :input').not(':button, :submit, :reset, :hidden, :checkbox, :radio').val('');
+            $('.filter :checkbox, :radio').prop('checked', false);
         });
 
-        // ---- Form valuidations -----------------------------------------
+        // ---- Form validations -----------------------------------------
 
         $('form').submit(function (event) {
 
-            //if ($(event.target).has('form .filter')) {
-            //    console.log("this is a filter form");
-
-            //    //document.cookie = “lastInputId = ' +  + ";" path = /Admin/MPs /; secrure”;
-            //    //document.cookie = “lastInputValue = ; path = /Admin/MPs /; secrure”;
-
-            //    // TODO: move the session storage assignment to here!
-            //    // sessionStorage.lastInputId = $(event.target).attr('id');
-            //    // sessionStorage.lastInputValue = $(event.target).val();
-            //}
+            if ($(event.target).has('form .filter')) {
+                console.log("this is a filter form");
+            }
 
             if ($(event.target).has('input .future-date')) {
                 if ($('#Date').val() < tomorrowsDate) {
@@ -154,6 +121,7 @@
         // --- Character counter -------------------------------------------
 
         var $textAreaWithCharCounter = $('#short-description');
+
         $textAreaWithCharCounter.on('keydown keyup paste', function (event) {
             updateCharCounterMsg($(this));
         });

--- a/ChapsDotNET/wwwroot/javascripts/chaps.js
+++ b/ChapsDotNET/wwwroot/javascripts/chaps.js
@@ -89,6 +89,19 @@
 
     $(document).ready(function () {
 
+        $('a.reset').click(function () {
+            $('#nameFilterTerm', '#addressFilterTerm', '#emailFilterTerm').val("");
+            $('#activeFilter').prop("checked", false);
+
+            // Remove any query strings
+            var uri = window.location.href.toString();
+            if (uri.indexOf("?") > 0) {
+                var clean_uri = uri.substring(0, uri.indexOf("?"));
+                window.history.replaceState({}, document.title, clean_uri);
+            }
+
+        });
+
         // Form validations
 
         $('form').submit(function (event) {

--- a/ChapsDotNET/wwwroot/javascripts/chaps.js
+++ b/ChapsDotNET/wwwroot/javascripts/chaps.js
@@ -83,29 +83,57 @@
     //  +---------------------------------------------------------------------------+
 
     $(document).ready(function () {
-        
-        $('form.filter').change(function (event) {
-            switch ($(event.target).attr('id')) {
-                case 'addressFilterTerm':
-                    $('#emailFilterTerm').val('');
-                    $('#nameFilterTerm').val('');
-                    break;
-                case 'emailFilterTerm':
-                    $('#addressFilterTerm').val('');
-                    $('#nameFilterTerm').val('');
-                    break;
-                case 'nameFilterTerm':
-                    $('#addressFilterTerm').val('');
-                    $('#emailFilterTerm').val('');
-                    break;
-                default:
-                    $('#addressFilterTerm').val('');
-                    $('#emailFilterTerm').val('');
-                    $('#nameFilterTerm').val('');
+
+
+        if ($(document.body).has('form')) {
+
+            if ($('form').hasClass('filter')) {
+
+                if (typeof (Storage) !== "undefined") {
+
+                    if ((sessionStorage.lastInputId === undefined) && (sessionStorage.lastInputValue === undefined)) {
+                        sessionStorage.lastInputId = "none";
+                        sessionStorage.lastInputValue = "none";
+                    }
+
+                    $('form.filter').on('change paste', function (event) {
+                        switch ($(event.target).attr('id')) {                            
+                            case 'addressFilterTerm':
+                                $('#emailFilterTerm, #nameFilterTerm').val('');
+                                sessionStorage.lastInputValue = $('#addressFilterTerm').val();
+                                break;
+                            case 'emailFilterTerm':
+                                $('#addressFilterTerm, #nameFilterTerm').val('');
+                                sessionStorage.lastInputValue = $('#emailFilterTerm').val();
+                                break;
+                            case 'nameFilterTerm':
+                                $('#addressFilterTerm, #emailFilterTerm').val('');
+                                sessionStorage.lastInputValue = $('#nameFilterTerm').val();
+                                break;
+                        }
+
+                        sessionStorage.lastInputId = $(event.target).attr('id');
+                    });
+                }
             }
-        });
+        }
+        // ----------------------------------------------------------------
+
+        // ---- Form valuidations -----------------------------------------
 
         $('form').submit(function (event) {
+
+            if ($(event.target).has('form .filter')) {
+                console.log("this is a filter form");
+
+                //document.cookie = “lastInputId = ' +  + ";" path = /Admin/MPs /; secrure”;
+                //document.cookie = “lastInputValue = ; path = /Admin/MPs /; secrure”;
+
+                // TODO: move the session storage assignment to here!
+                // sessionStorage.lastInputId = $(event.target).attr('id');
+                // sessionStorage.lastInputValue = $(event.target).val();
+            }
+
             if ($(event.target).has('input .future-date')) {
                 if ($('#Date').val() < tomorrowsDate) {
                     displayPastDateError();
@@ -114,8 +142,12 @@
                 else {
                     return true;
                 }
-            }         
+            }
+
+
         });
+
+        // --- Character counter -------------------------------------------
 
         var $textAreaWithCharCounter = $('#short-description');
         $textAreaWithCharCounter.on('keydown keyup paste', function (event) {

--- a/ChapsDotNET/wwwroot/javascripts/chaps.js
+++ b/ChapsDotNET/wwwroot/javascripts/chaps.js
@@ -83,6 +83,28 @@
     //  +---------------------------------------------------------------------------+
 
     $(document).ready(function () {
+        
+        $('form.filter').change(function (event) {
+            switch ($(event.target).attr('id')) {
+                case 'addressFilterTerm':
+                    $('#emailFilterTerm').val('');
+                    $('#nameFilterTerm').val('');
+                    break;
+                case 'emailFilterTerm':
+                    $('#addressFilterTerm').val('');
+                    $('#nameFilterTerm').val('');
+                    break;
+                case 'nameFilterTerm':
+                    $('#addressFilterTerm').val('');
+                    $('#emailFilterTerm').val('');
+                    break;
+                default:
+                    $('#addressFilterTerm').val('');
+                    $('#emailFilterTerm').val('');
+                    $('#nameFilterTerm').val('');
+            }
+        });
+
         $('form').submit(function (event) {
             if ($(event.target).has('input .future-date')) {
                 if ($('#Date').val() < tomorrowsDate) {

--- a/ChapsDotNET/wwwroot/javascripts/chaps.js
+++ b/ChapsDotNET/wwwroot/javascripts/chaps.js
@@ -119,6 +119,11 @@
         //}
         // ----------------------------------------------------------------
 
+        $('a.reset').click(function () {
+            var form = $(this).parents('form');
+            form.trigger("reset");
+        });
+
         // ---- Form valuidations -----------------------------------------
 
         $('form').submit(function (event) {
@@ -143,7 +148,6 @@
                     return true;
                 }
             }
-
 
         });
 

--- a/ChapsDotNET/wwwroot/javascripts/chaps.js
+++ b/ChapsDotNET/wwwroot/javascripts/chaps.js
@@ -89,15 +89,7 @@
 
     $(document).ready(function () {
 
-        //if ( $(document.body).has('form') ) {
-        //    if ( $('form').hasClass('filter') ) {
-        //        if ($(this).find(":checkbox#activeFilter") && hasQueryParams(window.location.href) == false ) {
-        //            $('input#activeFilter').prop("checked", true);
-        //        }
-        //    }
-        //}
-
-        // ---- Form validations -----------------------------------------
+        // Form validations
 
         $('form').submit(function (event) {
             if ($(event.target).has('input .future-date')) {
@@ -111,7 +103,7 @@
             }
         });
 
-        // --- Character counter -------------------------------------------
+        // Character counter
 
         var $textAreaWithCharCounter = $('#short-description');
 

--- a/ChapsDotNET/wwwroot/stylesheets/Site.css
+++ b/ChapsDotNET/wwwroot/stylesheets/Site.css
@@ -292,6 +292,11 @@ input[type="submit"] {
     vertical-align: middle;
 }
 
+.reset {
+    display: block;
+    margin: 2em 0 .5em 0;
+}
+
 /* MISC  
 ----------------------------------------------------------*/
 

--- a/ChapsDotNET/wwwroot/stylesheets/Site.css
+++ b/ChapsDotNET/wwwroot/stylesheets/Site.css
@@ -607,8 +607,9 @@ ul.recordMenu-tabs > li > a {
 }
 
 .alert > span {
-    padding-left: 20px;
     font-weight: bold;
+    padding-left: 20px;
+    padding-right: 6px;
 }
 
 span.error {


### PR DESCRIPTION
As a user, on the Admin > MPs page, I wish to filter the list of MPs by:

A) Name
B) Address
C) Email address
and combinations there of.

**Jira ticket**
https://dsdmoj.atlassian.net/browse/CDPT-392

---
_**1. New MP admin index page with filters:**_

![chaps-mp-index-page](https://user-images.githubusercontent.com/6988369/211868939-894ac1fa-6395-4e68-85ea-333d163749d1.png)

_**2. MP admin index page with responsive filter design:**_

![chaps-responsive-mp-index-page](https://user-images.githubusercontent.com/6988369/211869352-1cea3385-15b0-437d-a675-f3e37adbe24a.png)

_**3. Filtering results by name:**_

![chaps-filter-by-mp-name](https://user-images.githubusercontent.com/6988369/211869505-a31c8d01-8383-4b1d-b989-58d5ff569f3c.png)

_**4. Filtering results by name and address:**_

![chaps-filter-by-mp-name-address](https://user-images.githubusercontent.com/6988369/211869820-39af1eff-82ce-469c-be09-f2a88bff919f.png)

_**5. Filtering results by name, address and email:**_

![chaps-filter-by-mp-name-address-email](https://user-images.githubusercontent.com/6988369/211869941-bc1436ac-3073-43e8-9416-a4e3dee6f5df.png)

_**6. Proper 'No results' message**_

![chaps-no-results-page](https://user-images.githubusercontent.com/6988369/211870129-ac45ee78-e053-4660-8143-b197ff6c5387.png)
