### PR TITLE
combined build and run jobs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -36,8 +36,6 @@ jobs:
             --label build.git.branch=${{ github.ref }} \
             -f ChapsDotNET/Dockerfile \
             -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -t $REGISTRY/$REPOSITORY:dev-chaps.latest .
-      - name: Push to ECR
-        run: |
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
   deploy-dev:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The docker push command did not have access to the env: variables. Combine the two docker commands to fix this.