### PR TITLE
Amended ‘home’ breadcrumbs to point to old url.

### DIFF
--- a/ChapsDotNET/Areas/Admin/Views/Admin/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Admin/Index.cshtml
@@ -1,9 +1,17 @@
-﻿@{
+﻿@using ChapsDotNET.Common.Helpers
+@{
     ViewBag.Title = "Administration";
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
-<h6>@ViewBag.Title</h6>
+<div class="breadcrumbs">
+    <h6>
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
+        &nbsp;>&nbsp;
+        Administration
+    </h6>
+</div>
+
 
 <fieldset class="FieldsetCR">
     <legend>@Html.ActionLink("User management", "Index", "Users")</legend>

--- a/ChapsDotNET/Areas/Admin/Views/Admin/Lookups.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Admin/Lookups.cshtml
@@ -1,7 +1,0 @@
-﻿@{
-    ViewBag.Title = "Lookup administration";
-    Layout = "~/Views/Shared/_Layout.cshtml";
-}
-
-<h6>@Html.ActionLink("Administration", "Index", "Admin") > Lookups</h6>
-@await Html.PartialAsync("_LookupAdminList")

--- a/ChapsDotNET/Areas/Admin/Views/Alerts/Create.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Alerts/Create.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.AlertViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.AlertViewModel
 
 @{
     ViewData["Title"] = "Create a new alert";
@@ -14,9 +15,8 @@
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <script type="text/javascript" src="@Url.Content("~/lib/jquery-ui-timepicker-addon.js")"></script>
     <script type="text/javascript" src="@Url.Content("~/lib/jHtmlArea-0.8.min.js")" charset="utf-8"></script>
-     
-    <script type="text/javascript">
-        console.log($);
+
+    <script type="text/javascript">console.log($);
         console.log(jQuery);
         var jq = $.noConflict();
         jq(document).ready(function () {
@@ -33,7 +33,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -46,56 +46,56 @@
 {
     @Html.ValidationSummary(true)
 
-<fieldset class="form-fieldset">
-    <legend>
-        <h1>@ViewBag.Title</h1>
-    </legend>
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.WarnStart)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
-    <div class="editor-field">
-        @Html.TextBoxFor(model => model.WarnStartString, new { @class = "datetimepicker" })
-       
-        @Html.ValidationMessageFor(model => model.WarnStart)
-    </div>
-
-    <div class="editor-label">
-        @Html.LabelFor(model => model.RaisedHours)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
-
-    <div class="editor-field">
-        @Html.EditorFor(model => model.RaisedHours)
-        @Html.ValidationMessageFor(model => model.RaisedHours)
-    </div>
-
-    <div class="editor-label">
-        @Html.LabelFor(model => model.EventStart)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
-    <div class="editor-field">
-        @Html.TextBoxFor(model => model.EventStartString, new { @class = "datetimepicker" })
-        @Html.ValidationMessageFor(model => model.EventStart)
-    </div>
-
-    <div class="editor-row">
         <div class="editor-label">
-            @Html.LabelFor(model => model.Message)
+            @Html.LabelFor(model => model.WarnStart)
             <span title="Mandatory field" class="required-star">*</span>
         </div>
-        <div class="editor-field-long" id="jhtml">
-            <div style="width: 50%; float: left;">
-                @Html.TextAreaFor(model => model.Message, new { @id = "long-description", @class = "form-control", @style = "width:100%", @rows = "10" })
-                @Html.ValidationMessageFor(model => model.Message, "", new { @class = "text-danger" })
+        <div class="editor-field">
+            @Html.TextBoxFor(model => model.WarnStartString, new { @class = "datetimepicker" })
+
+            @Html.ValidationMessageFor(model => model.WarnStart)
+        </div>
+
+        <div class="editor-label">
+            @Html.LabelFor(model => model.RaisedHours)
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
+
+        <div class="editor-field">
+            @Html.EditorFor(model => model.RaisedHours)
+            @Html.ValidationMessageFor(model => model.RaisedHours)
+        </div>
+
+        <div class="editor-label">
+            @Html.LabelFor(model => model.EventStart)
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
+        <div class="editor-field">
+            @Html.TextBoxFor(model => model.EventStartString, new { @class = "datetimepicker" })
+            @Html.ValidationMessageFor(model => model.EventStart)
+        </div>
+
+        <div class="editor-row">
+            <div class="editor-label">
+                @Html.LabelFor(model => model.Message)
+                <span title="Mandatory field" class="required-star">*</span>
+            </div>
+            <div class="editor-field-long" id="jhtml">
+                <div style="width: 50%; float: left;">
+                    @Html.TextAreaFor(model => model.Message, new { @id = "long-description", @class = "form-control", @style = "width:100%", @rows = "10" })
+                    @Html.ValidationMessageFor(model => model.Message, "", new { @class = "text-danger" })
+                </div>
             </div>
         </div>
-    </div>
 
-    <input class="button" type="submit" value="Create" />
-    <button class="cancel-button" type="button" onclick="location.href='/Admin/Alerts/';">Cancel</button>
-</fieldset>
+        <input class="button" type="submit" value="Create" />
+        <button class="cancel-button" type="button" onclick="location.href='/Admin/Alerts/';">Cancel</button>
+    </fieldset>
 
     <style>
         #jhtml body {

--- a/ChapsDotNET/Areas/Admin/Views/Alerts/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Alerts/Edit.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.AlertViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.AlertViewModel
 
 @{
     ViewData["Title"] = "Edit an existing alert";
@@ -20,7 +21,7 @@
             jq(".datetimepicker").datetimepicker({
                 controlType: 'slider',
                 dateFormat: 'dd/mm/yy',
-                timeFormat: 'HH:mm',            
+                timeFormat: 'HH:mm',
                 changeMonth: true,
                 changeYear: true,
 
@@ -28,10 +29,9 @@
         });</script>
 }
 
-
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -50,7 +50,7 @@
         @Html.HiddenFor(model => model.AlertID)
 
         <div class="editor-label">
-            @Html.LabelFor(model => model.Live, new { @class="non-required-label"})
+            @Html.LabelFor(model => model.Live, new { @class = "non-required-label" })
         </div>
         <div class="editor-field">
             @Html.CheckBoxFor(model => model.Live)
@@ -75,7 +75,7 @@
             @Html.EditorFor(model => model.RaisedHours)
             @Html.ValidationMessageFor(model => model.RaisedHours)
         </div>
-       
+
 
         <div class="editor-label">
             @Html.LabelFor(model => model.EventStart)

--- a/ChapsDotNET/Areas/Admin/Views/Alerts/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Alerts/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model List<ChapsDotNET.Business.Models.AlertModel>
+﻿@using ChapsDotNET.Common.Helpers
+@model List<ChapsDotNET.Business.Models.AlertModel>
 
 @{
     ViewData["Title"] = "Alerts administration";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         > Alerts

--- a/ChapsDotNET/Areas/Admin/Views/Campaigns/Create.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Campaigns/Create.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.CampaignViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.CampaignViewModel
 
 @{
     ViewData["Title"] = "Create a new campaign";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -19,22 +20,22 @@
 {
     @Html.ValidationSummary(true)
 
-<fieldset class="form-fieldset">
-    <legend>
-        <h1>@ViewBag.Title</h1>
-    </legend>
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Detail)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Detail)
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Detail)
-        @Html.ValidationMessageFor(model => model.Detail)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Detail)
+            @Html.ValidationMessageFor(model => model.Detail)
+        </div>
 
-    <input class="button" type="submit" value="Create" />
-    <button class="cancel-button" type="button" onclick="location.href='/Admin/Campaigns/';">Cancel</button>
-</fieldset>
+        <input class="button" type="submit" value="Create" />
+        <button class="cancel-button" type="button" onclick="location.href='/Admin/Campaigns/';">Cancel</button>
+    </fieldset>
 }

--- a/ChapsDotNET/Areas/Admin/Views/Campaigns/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Campaigns/Edit.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.CampaignViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.CampaignViewModel
 
 @{
     ViewData["Title"] = "Edit an existing campaign";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;

--- a/ChapsDotNET/Areas/Admin/Views/Campaigns/index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Campaigns/index.cshtml
@@ -1,4 +1,5 @@
-﻿@model List<ChapsDotNET.Business.Models.CampaignModel>
+﻿@using ChapsDotNET.Common.Helpers
+@model List<ChapsDotNET.Business.Models.CampaignModel>
 
 @{
     ViewData["Title"] = "Campaigns administration";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         > Campaigns

--- a/ChapsDotNET/Areas/Admin/Views/LeadSubjects/Create.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/LeadSubjects/Create.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.LeadSubjectViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.LeadSubjectViewModel
 
 @{
     ViewData["Title"] = "Add a new lead subject";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -19,23 +20,23 @@
 {
     @Html.ValidationSummary(true)
 
-<fieldset class="form-fieldset">
-    <legend>
-        <h1>@ViewBag.Title</h1>
-    </legend>
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Detail)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Detail)
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Detail)
-        @Html.ValidationMessageFor(model => model.Detail)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Detail)
+            @Html.ValidationMessageFor(model => model.Detail)
+        </div>
 
-    <input type="submit" value="Create" />
-    <button class="cancel-button" type="button" onclick="location.href='/Admin/LeadSubjects/';">Cancel</button>
-</fieldset>
+        <input type="submit" value="Create" />
+        <button class="cancel-button" type="button" onclick="location.href='/Admin/LeadSubjects/';">Cancel</button>
+    </fieldset>
 
 }

--- a/ChapsDotNET/Areas/Admin/Views/LeadSubjects/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/LeadSubjects/Edit.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.LeadSubjectViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.LeadSubjectViewModel
 
 @{
     ViewData["Title"] = "Edit an existing lead subject";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;

--- a/ChapsDotNET/Areas/Admin/Views/LeadSubjects/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/LeadSubjects/Index.cshtml
@@ -1,12 +1,13 @@
-﻿@model List<ChapsDotNET.Business.Models.LeadSubjectModel>
+﻿@using ChapsDotNET.Common.Helpers
+@model List<ChapsDotNET.Business.Models.LeadSubjectModel>
 
 @{
-    ViewData["Title"] = "Lead Subject Administration";
+    ViewData["Title"] = "Lead subject administration";
 }
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         > Lead Subjects

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Create.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Create.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.MPViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.MPViewModel
 
 @{
     ViewData["Title"] = "Add a new Member of Parliament";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -16,7 +17,7 @@
 </div>
 
 @using (Html.BeginForm())
-    {
+{
     @Html.ValidationSummary(true)
 
     <fieldset class="form-fieldset">

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Edit.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.MPViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.MPViewModel
 
 @{
     ViewData["Title"] = "Edit a Member of Parliament";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -19,120 +20,120 @@
 {
     @Html.HiddenFor(model => model.MPId)
 
-<fieldset class="form-fieldset">
-    <legend>
-        <h1>@ViewBag.Title</h1>
-    </legend>
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.RtHon, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.CheckBoxFor(model => model.RtHon)
-        @Html.ValidationMessageFor(model => model.RtHon)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.RtHon, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.CheckBoxFor(model => model.RtHon)
+            @Html.ValidationMessageFor(model => model.RtHon)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.SalutationId)
-    </div>
-    <div class="editor-field">
-        @Html.DropDownListFor(m => m.SalutationId, Model.SalutationList, "Select a Salutation")
-        @Html.ValidationMessageFor(model => model.SalutationId)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.SalutationId)
+        </div>
+        <div class="editor-field">
+            @Html.DropDownListFor(m => m.SalutationId, Model.SalutationList, "Select a Salutation")
+            @Html.ValidationMessageFor(model => model.SalutationId)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.FirstNames, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.FirstNames)
-        @Html.ValidationMessageFor(model => model.FirstNames)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.FirstNames, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.FirstNames)
+            @Html.ValidationMessageFor(model => model.FirstNames)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Surname)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Surname)
-        @Html.ValidationMessageFor(model => model.Surname)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Surname)
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Surname)
+            @Html.ValidationMessageFor(model => model.Surname)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Suffix, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Suffix)
-        @Html.ValidationMessageFor(model => model.Suffix)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Suffix, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Suffix)
+            @Html.ValidationMessageFor(model => model.Suffix)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.AddressLine1, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.AddressLine1)
-        @Html.ValidationMessageFor(model => model.AddressLine1)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.AddressLine1, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.AddressLine1)
+            @Html.ValidationMessageFor(model => model.AddressLine1)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.AddressLine2, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.AddressLine2)
-        @Html.ValidationMessageFor(model => model.AddressLine2)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.AddressLine2, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.AddressLine2)
+            @Html.ValidationMessageFor(model => model.AddressLine2)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.AddressLine3, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.AddressLine3)
-        @Html.ValidationMessageFor(model => model.AddressLine3)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.AddressLine3, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.AddressLine3)
+            @Html.ValidationMessageFor(model => model.AddressLine3)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Town, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Town)
-        @Html.ValidationMessageFor(model => model.Town)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Town, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Town)
+            @Html.ValidationMessageFor(model => model.Town)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.County, new { @class = "non-required-label" })
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.County, new { @class = "non-required-label" })
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.County)
-        @Html.ValidationMessageFor(model => model.County)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.County)
+            @Html.ValidationMessageFor(model => model.County)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Postcode, new { @class = "non-required-label" })
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Postcode, new { @class = "non-required-label" })
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Postcode)
-        @Html.ValidationMessageFor(model => model.Postcode)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Postcode)
+            @Html.ValidationMessageFor(model => model.Postcode)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Email, new { @class = "non-required-label" })
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Email, new { @class = "non-required-label" })
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Email)
-        @Html.ValidationMessageFor(model => model.Email)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Email)
+            @Html.ValidationMessageFor(model => model.Email)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Active, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.CheckBoxFor(model => model.Active)
-        @Html.ValidationMessageFor(model => model.Active)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Active, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.CheckBoxFor(model => model.Active)
+            @Html.ValidationMessageFor(model => model.Active)
+        </div>
 
-    <input class="button" type="submit" value="Save" />
-    <button class="cancel-button" type="button" onclick="location.href='/Admin/Mps/';">Cancel</button>
-</fieldset>
+        <input class="button" type="submit" value="Save" />
+        <button class="cancel-button" type="button" onclick="location.href='/Admin/Mps/';">Cancel</button>
+    </fieldset>
 }

--- a/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MPs/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@using ChapsDotNET.Models
+@using ChapsDotNET.Common.Helpers 
 @model IndexViewModel
 
 @{
@@ -28,7 +29,7 @@
     @Html.AntiForgeryToken()
     <div class="breadcrumbs">
         <h6>
-            @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+            <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
             &nbsp;>&nbsp;
             @Html.ActionLink("Administration", "Index", "Admin")
             > MPs

--- a/ChapsDotNET/Areas/Admin/Views/MoJMinisters/Create.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MoJMinisters/Create.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.MoJMinisterViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.MoJMinisterViewModel
 
 @{
     ViewData["Title"] = "Add a new MoJ Minister";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -19,45 +20,45 @@
 {
     @Html.ValidationSummary(true)
 
-<fieldset class="form-fieldset">
-    <legend>
-        <h1>@ViewBag.Title</h1>
-    </legend>
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Prefix, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Prefix)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Prefix, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Prefix)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Name)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Name)
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Name)
-        @Html.ValidationMessageFor(model => model.Name)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Name)
+            @Html.ValidationMessageFor(model => model.Name)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Suffix, new { @class = "non-required-label" })
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Suffix, new { @class = "non-required-label" })
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Suffix)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Suffix)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Rank, new { @class = "non-required-label" })
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Rank, new { @class = "non-required-label" })
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Rank)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Rank)
+        </div>
 
-    <input type="submit" value="Create" />
-    <button class="cancel-button" type="button" onclick="location.href='/Admin/MOJMinisters/';">Cancel</button>
-</fieldset>
+        <input type="submit" value="Create" />
+        <button class="cancel-button" type="button" onclick="location.href='/Admin/MOJMinisters/';">Cancel</button>
+    </fieldset>
 }

--- a/ChapsDotNET/Areas/Admin/Views/MoJMinisters/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MoJMinisters/Edit.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.MoJMinisterViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.MoJMinisterViewModel
 
 @{
     ViewData["Title"] = "Edit an MoJ Minister";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -20,59 +21,58 @@
 
     @Html.HiddenFor(model => model.MoJMinisterId)
 
-<fieldset class="form-fieldset">
-    <legend>
-        <h1>@ViewBag.Title</h1>
-    </legend>
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Prefix, new { @class = "non-required-label" })
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Prefix, new { @class = "non-required-label" })
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Prefix)
-        @Html.ValidationMessageFor(model => model.Prefix)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Prefix)
+            @Html.ValidationMessageFor(model => model.Prefix)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Name)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Name)
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Name)
-        @Html.ValidationMessageFor(model => model.Name)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Name)
+            @Html.ValidationMessageFor(model => model.Name)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Suffix, new { @class = "non-required-label" })
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Suffix, new { @class = "non-required-label" })
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Suffix)
-        @Html.ValidationMessageFor(model => model.Suffix)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Suffix)
+            @Html.ValidationMessageFor(model => model.Suffix)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Rank, new { @class = "non-required-label" })
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Rank, new { @class = "non-required-label" })
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Rank)
-        @Html.ValidationMessageFor(model => model.Rank)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Rank)
+            @Html.ValidationMessageFor(model => model.Rank)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Active, new { @class = "non-required-label" })
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Active, new { @class = "non-required-label" })
+        </div>
 
-    <div class="editor-field">
-        @Html.CheckBoxFor(model => model.Active)
-        @Html.ValidationMessageFor(model => model.Active)
-    </div>
+        <div class="editor-field">
+            @Html.CheckBoxFor(model => model.Active)
+            @Html.ValidationMessageFor(model => model.Active)
+        </div>
 
-    <input class="button" type="submit" value="Save" />
-    <button class="cancel-button" type="button" onclick="location.href='/Admin/MOJMinisters/';">Cancel</button>
-</fieldset>
+        <input class="button" type="submit" value="Save" />
+        <button class="cancel-button" type="button" onclick="location.href='/Admin/MOJMinisters/';">Cancel</button>
+    </fieldset>
 }
-    

--- a/ChapsDotNET/Areas/Admin/Views/MoJMinisters/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/MoJMinisters/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model List<ChapsDotNET.Business.Models.MoJMinisterModel>
+﻿@using ChapsDotNET.Common.Helpers
+@model List<ChapsDotNET.Business.Models.MoJMinisterModel>
 
 @{
     ViewData["Title"] = "MoJ Minister administration";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         > MoJ Ministers

--- a/ChapsDotNET/Areas/Admin/Views/PublicHolidays/Create.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/PublicHolidays/Create.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.PublicHolidayViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.PublicHolidayViewModel
 
 @{
     ViewData["Title"] = "Create a new public holiday";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;

--- a/ChapsDotNET/Areas/Admin/Views/PublicHolidays/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/PublicHolidays/Edit.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.PublicHolidayViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.PublicHolidayViewModel
 
 @{
     ViewData["Title"] = "Edit an existing public holiday";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -20,39 +21,39 @@
     @Html.ValidationSummary(true)
     @Html.HiddenFor(model => model.PublicHolidayId)
 
-<fieldset class="form-fieldset">
-    <legend>
-        <h1>@ViewBag.Title</h1>
-    </legend>
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Date)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Date)
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Date, "{0:yyyy-MM-dd}", new
-            {
-                @class = "future-date",
-                @type = "date",
-                @value = ""
-            })
-        <div style="clear: both;"></div>
-        @Html.ValidationMessageFor(model => model.Date)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Date, "{0:yyyy-MM-dd}", new
+                {
+                    @class = "future-date",
+                    @type = "date",
+                    @value = ""
+                })
+            <div style="clear: both;"></div>
+            @Html.ValidationMessageFor(model => model.Date)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Description)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Description)
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Description)
-        @Html.ValidationMessageFor(model => model.Description)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Description)
+            @Html.ValidationMessageFor(model => model.Description)
+        </div>
 
-    <input class="createButton" type="submit" value="Save" />
-    <button class="cancel-button" type="button" onclick="location.href='/Admin/PublicHolidays/';">Cancel</button>
+        <input class="createButton" type="submit" value="Save" />
+        <button class="cancel-button" type="button" onclick="location.href='/Admin/PublicHolidays/';">Cancel</button>
 
-</fieldset>
+    </fieldset>
 }

--- a/ChapsDotNET/Areas/Admin/Views/PublicHolidays/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/PublicHolidays/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model List<ChapsDotNET.Business.Models.PublicHolidayModel>
+﻿@using ChapsDotNET.Common.Helpers 
+@model List<ChapsDotNET.Business.Models.PublicHolidayModel>
 
 @{
     ViewData["Title"] = "Public holidays administration";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         > Public Holidays

--- a/ChapsDotNET/Areas/Admin/Views/Report/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Report/Edit.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.ReportViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.ReportViewModel
 
 @{
     ViewData["Title"] = "Edit an existing report";
@@ -6,14 +7,14 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
         @Html.ActionLink("Reports", "Index", "Report")
         > Edit
     </h6>
- 
+
 </div>
 
 @using (Html.BeginForm(new { @class = "form", @id = "create_report_form" }))
@@ -25,29 +26,29 @@
         @Html.HiddenFor(model => model.ReportId)
         @Html.HiddenFor(model => model.Name)
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Description)
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
-    <div class="editor-field" id="jhtml">
-        @Html.TextAreaFor(model => model.Description, new
-        {
-            @id = "short-description",
-            @class = "withCharacterCount form-control",
-            data_limit_input = "" + @Html.DisplayFor(model => model.MaxLengthShort) + "",
-            @style = "width:50%",
-            @rows = "10"
-        })<br />
-        @Html.ValidationMessageFor(model => model.Description)
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Description)
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
+        <div class="editor-field" id="jhtml">
+            @Html.TextAreaFor(model => model.Description, new
+            {
+                @id = "short-description",
+                @class = "withCharacterCount form-control",
+                data_limit_input = "" + @Html.DisplayFor(model => model.MaxLengthShort) + "",
+                @style = "width:50%",
+                @rows = "10"
+            })<br />
+            @Html.ValidationMessageFor(model => model.Description)
 
-    </div>
-    <div class="editor-label">
-        @Html.LabelFor(model => model.LongDescription)
-    </div>
-    <div class="editor-field">
-        @Html.TextAreaFor(model => model.LongDescription, new { @id = "long-description", @class = "form-control", @style = "width:50%", @rows = "10" })
-        @Html.ValidationMessageFor(model => model.LongDescription)
-    </div>
+        </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.LongDescription)
+        </div>
+        <div class="editor-field">
+            @Html.TextAreaFor(model => model.LongDescription, new { @id = "long-description", @class = "form-control", @style = "width:50%", @rows = "10" })
+            @Html.ValidationMessageFor(model => model.LongDescription)
+        </div>
 
         <input class="createButton" type="submit" value="Save" />
         <button class="cancel-button" type="button" onclick="location.href='/Admin/Report/';">Cancel</button>

--- a/ChapsDotNET/Areas/Admin/Views/Report/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Report/Index.cshtml
@@ -1,7 +1,8 @@
-﻿@model List<ChapsDotNET.Business.Models.ReportModel>
+﻿@using ChapsDotNET.Common.Helpers
+@model List<ChapsDotNET.Business.Models.ReportModel>
 
 @{
-    ViewData["Title"] = "Reports Administration";
+    ViewData["Title"] = "Reports administration";
 }
 
 @section head{
@@ -10,7 +11,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         > Reports

--- a/ChapsDotNET/Areas/Admin/Views/Salutations/Create.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Salutations/Create.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.SalutationViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.SalutationViewModel
 
 @{
     ViewData["Title"] = "Add a new salutation";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;

--- a/ChapsDotNET/Areas/Admin/Views/Salutations/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Salutations/Edit.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.SalutationViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.SalutationViewModel
 
 @{
     ViewData["Title"] = "Edit an existing salutation";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -24,7 +25,7 @@
 
         @Html.HiddenFor(model => model.SalutationId)
         <div class="editor-label">
-            @Html.LabelFor(model => model.Active, new { @class="non-required-label"})
+            @Html.LabelFor(model => model.Active, new { @class = "non-required-label" })
         </div>
 
         <div class="editor-field">

--- a/ChapsDotNET/Areas/Admin/Views/Salutations/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Salutations/Index.cshtml
@@ -3,7 +3,7 @@
 @model ChapsDotNET.Business.Models.Common.PagedResult<List<ChapsDotNET.Business.Models.SalutationModel>>
 
 @{
-    ViewData["Title"] = "Salutations Administration";
+    ViewData["Title"] = "Salutations administration";
 }
 
 @section head{
@@ -12,7 +12,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         > Salutations

--- a/ChapsDotNET/Areas/Admin/Views/Teams/Create.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Teams/Create.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.TeamViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.TeamViewModel
 
 @{
     ViewData["Title"] = "Create a new team";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;

--- a/ChapsDotNET/Areas/Admin/Views/Teams/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Teams/Edit.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.TeamViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.TeamViewModel
 
 @{
     ViewBag.Title = "Edit team";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -19,68 +20,68 @@
 {
     @Html.ValidationSummary(true)
 
-<fieldset class="form-fieldset">
-    <legend>
-        <h1>@ViewBag.Title</h1>
-    </legend>
-    @Html.HiddenFor(model => model.TeamId)
-  
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
+        @Html.HiddenFor(model => model.TeamId)
 
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Active, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Active)
-        @Html.ValidationMessageFor(model => model.Active)
-    </div>
+
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Active, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Active)
+            @Html.ValidationMessageFor(model => model.Active)
+        </div>
 
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Acronym)
-        <span alt="Mandatory field" class="required-star">*</span>
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Acronym)
-        @Html.ValidationMessageFor(model => model.Acronym)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Acronym)
+            <span alt="Mandatory field" class="required-star">*</span>
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Acronym)
+            @Html.ValidationMessageFor(model => model.Acronym)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Name)
-        <span alt="Mandatory field" class="required-star">*</span>
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Name)
-        @Html.ValidationMessageFor(model => model.Name)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Name)
+            <span alt="Mandatory field" class="required-star">*</span>
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Name)
+            @Html.ValidationMessageFor(model => model.Name)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.IsOgd, new { @class = "non-required-label" })
+        <div class="editor-label">
+            @Html.LabelFor(model => model.IsOgd, new { @class = "non-required-label" })
 
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.IsOgd)
-        @Html.ValidationMessageFor(model => model.IsOgd)
-    </div>
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.IsOgd)
+            @Html.ValidationMessageFor(model => model.IsOgd)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.IsPod, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.IsPod)
-        @Html.ValidationMessageFor(model => model.IsPod)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.IsPod, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.IsPod)
+            @Html.ValidationMessageFor(model => model.IsPod)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Email, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Email)
-        @Html.ValidationMessageFor(model => model.Email)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Email, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Email)
+            @Html.ValidationMessageFor(model => model.Email)
+        </div>
 
-    <input class="createButton" type="submit" value="Save" />
-    <button class="cancel-button" type="button" onclick="location.href='/Admin/Teams/';">Cancel</button>
-</fieldset>
+        <input class="createButton" type="submit" value="Save" />
+        <button class="cancel-button" type="button" onclick="location.href='/Admin/Teams/';">Cancel</button>
+    </fieldset>
 
 }

--- a/ChapsDotNET/Areas/Admin/Views/Teams/Index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Teams/Index.cshtml
@@ -1,12 +1,13 @@
-﻿@model List<ChapsDotNET.Business.Models.TeamModel>
+﻿@using ChapsDotNET.Common.Helpers
+@model List<ChapsDotNET.Business.Models.TeamModel>
 
 @{
-    ViewData["Title"] = "Teams Administration";
+    ViewData["Title"] = "Teams administration";
 }
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         > Teams

--- a/ChapsDotNET/Areas/Admin/Views/Users/Create.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Users/Create.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.UserViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.UserViewModel
 
 @{
     ViewData["Title"] = "Create a new user";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;
@@ -19,57 +20,57 @@
 {
     @Html.ValidationSummary(true)
 
-<fieldset class="form-fieldset">
-    <legend>
-        <h1>@ViewBag.Title</h1>
-    </legend>
+    <fieldset class="form-fieldset">
+        <legend>
+            <h1>@ViewBag.Title</h1>
+        </legend>
 
-    <div class="editor-label">
-        <label for="Detail">Name</label>
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
+        <div class="editor-label">
+            <label for="Detail">Name</label>
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Name)
-        @Html.ValidationMessageFor(model => model.Name)
-    </div>
-    <div class="editor-label">
-        <label for="Detail">Display Name</label>
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Name)
+            @Html.ValidationMessageFor(model => model.Name)
+        </div>
+        <div class="editor-label">
+            <label for="Detail">Display Name</label>
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
 
-    <div class="editor-field">
-        @Html.EditorFor(model => model.DisplayName)
-        @Html.ValidationMessageFor(model => model.DisplayName)
-    </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.DisplayName)
+            @Html.ValidationMessageFor(model => model.DisplayName)
+        </div>
 
-    <div class="editor-label">
-        @Html.LabelFor(model => model.Email, new { @class = "non-required-label" })
-    </div>
-    <div class="editor-field">
-        @Html.EditorFor(model => model.Email)
-        @Html.ValidationMessageFor(model => model.Email)
-    </div>
+        <div class="editor-label">
+            @Html.LabelFor(model => model.Email, new { @class = "non-required-label" })
+        </div>
+        <div class="editor-field">
+            @Html.EditorFor(model => model.Email)
+            @Html.ValidationMessageFor(model => model.Email)
+        </div>
 
-    <div class="editor-label">
-        <label for="Detail">Role</label>
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
+        <div class="editor-label">
+            <label for="Detail">Role</label>
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
 
-    <div class="editor-field">
-        @Html.DropDownListFor(model => model.RoleStrength, Model.RoleList, "Please select a role", new { @class = "required" })
-        @Html.ValidationMessageFor(model => model.RoleStrength)
-    </div>
-    <div class="editor-label">
-        <label for="Detail">Team</label>
-        <span title="Mandatory field" class="required-star">*</span>
-    </div>
-    <div class="editor-field">
-        @Html.DropDownListFor(model => model.TeamId, Model.TeamList, "Please select an office", new { @class = "required" })
-        @Html.ValidationMessageFor(model => model.TeamId)
-    </div>
+        <div class="editor-field">
+            @Html.DropDownListFor(model => model.RoleStrength, Model.RoleList, "Please select a role", new { @class = "required" })
+            @Html.ValidationMessageFor(model => model.RoleStrength)
+        </div>
+        <div class="editor-label">
+            <label for="Detail">Team</label>
+            <span title="Mandatory field" class="required-star">*</span>
+        </div>
+        <div class="editor-field">
+            @Html.DropDownListFor(model => model.TeamId, Model.TeamList, "Please select an office", new { @class = "required" })
+            @Html.ValidationMessageFor(model => model.TeamId)
+        </div>
 
-     <input class="createButton" type="submit" value="Create" />
-    <button class="cancel-button" type="button" onclick="location.href='/Admin/users/';">Cancel</button>
-</fieldset>
+        <input class="createButton" type="submit" value="Create" />
+        <button class="cancel-button" type="button" onclick="location.href='/Admin/users/';">Cancel</button>
+    </fieldset>
 }

--- a/ChapsDotNET/Areas/Admin/Views/Users/Edit.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Users/Edit.cshtml
@@ -1,4 +1,5 @@
-﻿@model ChapsDotNET.Models.UserViewModel
+﻿@using ChapsDotNET.Common.Helpers
+@model ChapsDotNET.Models.UserViewModel
 
 @{
     ViewData["Title"] = "Edit an existing user";
@@ -6,7 +7,7 @@
 
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         &nbsp;>&nbsp;

--- a/ChapsDotNET/Areas/Admin/Views/Users/index.cshtml
+++ b/ChapsDotNET/Areas/Admin/Views/Users/index.cshtml
@@ -27,7 +27,7 @@
 }
 <div class="breadcrumbs">
     <h6>
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, null)
+        <a href="@UrlHelpers.GetTpUrl(Context)">Home</a>
         &nbsp;>&nbsp;
         @Html.ActionLink("Administration", "Index", "Admin")
         > Users

--- a/ChapsDotNET/Common/Helpers/Helpers.cs
+++ b/ChapsDotNET/Common/Helpers/Helpers.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Html;
 using System;
 using System.IO;
+using Microsoft.EntityFrameworkCore;
 
 namespace ChapsDotNET.Common.Helpers
 {
@@ -28,6 +29,29 @@ namespace ChapsDotNET.Common.Helpers
             }
 
             return contentBuilder;
+        }
+    }
+
+    public static class UrlHelpers
+    {
+        public static string GetTpUrl(HttpContext context)
+        {
+            var currentEnvironment = context.Request.Host.Value.ToString();
+            string? environment;
+            if (currentEnvironment.Contains("staging"))
+            {
+                environment = "staging.";
+            }
+            else if (currentEnvironment.Contains("dev") || currentEnvironment.Contains("localhost"))
+            {
+                environment = "dev.";
+            }
+            else
+            {
+                environment = "production.";
+            }
+
+            return $"https://chaps.{environment}net.tp.dsd.io/Chaps_deploy";
         }
     }
 }

--- a/ChapsDotNET/Views/Shared/_MenuBar.cshtml
+++ b/ChapsDotNET/Views/Shared/_MenuBar.cshtml
@@ -1,25 +1,28 @@
 ﻿@using ChapsDotNET.Business.Interfaces
+@using ChapsDotNET.Common.Helpers 
 
 @inject IUserComponent UserComponent
 
 @{
     var user = await UserComponent.GetUserByNameAsync(User.Identity?.Name);
-    var currentEnvironment = Context.Request.Host.Value.ToString();
-    var environment = string.Empty;
-    if (currentEnvironment.Contains("staging"))
-    {
-        environment = "staging.";
-    }
-    else if (currentEnvironment.Contains("dev") || currentEnvironment.Contains("localhost"))
-    {
-        environment = "dev.";
-    }
-    else
-    {
-        environment = "production.";
-    }
 
-    var targetUrl = $"https://chaps.{environment}net.tp.dsd.io/Chaps_deploy";
+    var targetUrl = UrlHelpers.GetTpUrl(Context);
+    //var currentEnvironment = Context.Request.Host.Value.ToString();
+    //var environment = string.Empty;
+    //if (currentEnvironment.Contains("staging"))
+    //{
+    //    environment = "staging.";
+    //}
+    //else if (currentEnvironment.Contains("dev") || currentEnvironment.Contains("localhost"))
+    //{
+    //    environment = "dev.";
+    //}
+    //else
+    //{
+    //    environment = "production.";
+    //}
+
+    //var targetUrl = $"https://chaps.{environment}net.tp.dsd.io/Chaps_deploy";
 }
 
 <div id="MenuContainer">


### PR DESCRIPTION
Clicking the home link in the breadcrumbs e.g. "Home > Administration > Salutations > Create" should take the user to the url https://chaps.{environment}.net.tp.dsd.io/Chaps_deploy/. where {environment} is either dev, staging or production respectively. 